### PR TITLE
ci: fix pnpm drift, add Node matrix, non-UTC leg, and concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,26 +6,63 @@ on:
   pull_request:
     branches: [main]
 
+# Supersede in-flight runs for the same ref rather than letting them finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
+    name: build-and-test (node ${{ matrix.node }}, TZ ${{ matrix.tz }})
     runs-on: ubuntu-latest
+
+    # Only the America/Chicago leg is allowed to fail, and only until #13 lands.
+    # See the matrix comment below.
+    continue-on-error: ${{ matrix.experimental }}
+
+    strategy:
+      # One failing leg must not cancel the others - the whole point of a matrix
+      # is knowing which environments break, not just that one did.
+      fail-fast: false
+      matrix:
+        node: [18, 20, 22, 24]
+        tz: [UTC]
+        experimental: [false]
+        include:
+          # Non-UTC leg. GitHub runners are UTC, which hid a real date-parsing
+          # defect for months: parseDate reads YYYY-MM-DD as UTC midnight and
+          # formats it with local getters, so date-only events render a day
+          # early at negative offsets. Locally: 55/55 pass under TZ=UTC,
+          # 54/55 under TZ=America/Chicago.
+          #
+          # This leg is EXPECTED TO FAIL until #13 is fixed. It is marked
+          # experimental so it reports red without blocking merges in the
+          # meantime. The #13 fix PR must delete this include entry's
+          # `experimental: true` so the leg becomes blocking.
+          - node: 20
+            tz: America/Chicago
+            experimental: true
+
+    env:
+      TZ: ${{ matrix.tz }}
 
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` input - the pnpm version is read from the
+      # `packageManager` field in package.json, so CI and local development
+      # cannot drift apart.
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node }}
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Lint
         run: pnpm lint
@@ -38,6 +75,28 @@ jobs:
 
       - name: Unit tests
         run: pnpm test
+
+  e2e:
+    name: e2e
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: pnpm build:lib
 
       - name: Install Playwright browsers
         run: pnpm --filter demo exec playwright install chromium

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # No `version:` input - read from `packageManager` in package.json.
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -28,7 +27,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build library
         run: pnpm build:lib


### PR DESCRIPTION
Closes #11. First implementation step of the [repo hardening plan](plans/2026-08-12-repo-hardening-plan.md) (§6).

Four independent defects, one file each for CI and release.

## 1. pnpm version drift

The workflow pinned pnpm **8** while `package.json` declares `"packageManager": "pnpm@9.0.0"` — CI and local dev resolved different trees. Dropped the explicit `version:` input so it derives from `packageManager`, and bumped `pnpm/action-setup` v2 → v4. Same fix in `release.yml`.

## 2. Support matrix

`engines` claims `>=18`; only Node 20 was ever exercised. Now 18/20/22/24 with `fail-fast: false`, so a bad environment names itself instead of killing the run.

If Node 18 fails, that is a real finding — the plan permits either fixing it or narrowing `engines`, and this is how we find out.

## 3. Non-UTC timezone leg

GitHub runners are UTC. `parseDate` reads `YYYY-MM-DD` as UTC midnight and formats with local getters, so date-only events render a day early at negative offsets.

Measured locally on this branch:

| `TZ` | Result |
|---|---|
| `UTC` | 55/55 pass |
| `America/Chicago` | **54/55** — `dateUtils.test.ts > parseDate > parses ISO 8601 date strings` |

UTC-only CI is precisely why that defect sat green for eight months.

**This leg is expected to fail until #13 lands.** It is marked `experimental` so it reports red without blocking merges. The #13 fix PR must delete `experimental: true` from the include entry to make it blocking — that is the whole point of adding it now.

## 4. Concurrency

Superseded runs ran to completion on every rapid push. Added a workflow+ref group with `cancel-in-progress: true`.

**Deliberately not added to `release.yml`** — cancelling an in-flight publish is worse than letting a redundant one finish.

## Structural change: e2e is now its own job

Running Playwright on every matrix leg would quadruple e2e time for no additional signal. It runs once on Node 20.

## The check-name rename — this is the ordering trap

Before: one check, `build-and-test`. After, six:

```
build-and-test (node 18, TZ UTC)
build-and-test (node 20, TZ UTC)
build-and-test (node 22, TZ UTC)
build-and-test (node 24, TZ UTC)
build-and-test (node 20, TZ America/Chicago)   <- experimental
e2e
```

This is exactly why the plan sequences #11 before #7. Had the ruleset been applied first, it would have required `build-and-test`, which no longer reports, and **every PR would block forever**.

Once this merges, the observed names get posted to #7 so the ruleset pins the right strings. The experimental leg should **not** be marked required until #13 lands.

## Verification

- Both workflows parse as valid YAML; matrix expansion simulated → 5 legs + e2e
- `TZ` behavior measured locally (table above)
- Real proof is this PR's own run — the check list below is the deliverable

Refs #7, #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)