### PR TITLE
ci: add CodeQL code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, Monday 04:27 UTC. Off-peak and deliberately not on the hour -
+    # GitHub throttles schedules that bunch at :00.
+    - cron: '27 4 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Least privilege: only what the CodeQL action actually needs.
+      security-events: write # upload results to the Security tab
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # javascript-typescript covers the library and the demo.
+        #
+        # actions scans the workflow files themselves for injection and
+        # untrusted-input issues. Included because this repository's
+        # workflows are part of the release path to npm - a compromised
+        # workflow is a supply-chain problem, not a CI inconvenience.
+        language: [javascript-typescript, actions]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      # No build step. JavaScript/TypeScript and Actions are analyzed
+      # directly from source, so `pnpm build` would add time without
+      # changing what CodeQL sees.
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Closes #9. Third step of the [repo hardening plan](plans/2026-08-12-repo-hardening-plan.md) (§4), and the last piece before #7 becomes actionable.

## Why advanced setup

GitHub's **default setup** is `not-configured` on this repo (verified via the API), so a workflow-based setup cannot conflict with it. Advanced setup is used because it puts the configuration in version control, where it is reviewable and diffable — consistent with the rest of this milestone.

Repository is public, so CodeQL is free.

## Scope note — one deliberate addition

The issue specified `javascript-typescript`. This scans **two** languages:

| Language | Covers |
|---|---|
| `javascript-typescript` | the library and the demo |
| `actions` | the workflow files themselves |

Flagging the addition rather than slipping it in. The reasoning: `release.yml` holds `NPM_TOKEN` and publishes to npm on tag push. A workflow-injection flaw there is a **supply-chain compromise of a published package**, not a CI inconvenience — and this milestone just authored two workflow files. Cost is one extra matrix leg.

Say the word if you'd rather keep it to the issue text and I'll drop the `actions` leg.

## Configuration choices

**No build step.** Both languages are analyzed from source. Running `pnpm build` would add time without changing what CodeQL sees.

**Scoped permissions** — `security-events: write`, `actions: read`, `contents: read` — rather than inheriting the default token scope.

**Default query suite**, not `security-and-quality`. Keeps signal high on a ~3,800-line codebase. Easy to widen later if the findings are thin.

**Weekly schedule at 04:27 UTC Monday.** Off-hour on purpose: GitHub throttles schedules bunched at `:00`.

## Two new check-name candidates for #7

```
analyze (javascript-typescript)
analyze (actions)
```

I'll post these to #7 alongside the CI names once this merges, so the ruleset can be applied in one pass.

## Verification

- YAML parses; matrix expands to the two legs above
- Default setup confirmed `not-configured` before adding this
- Real proof is this PR's own run and whether the Security tab populates
- Per the issue's acceptance criteria, any findings get triaged — fixed, or dismissed with a stated reason. I'll report what it finds.

Refs #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)