### PR TITLE
fix: parse date-only strings as local midnight, not UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,6 @@ jobs:
     name: build-and-test (node ${{ matrix.node }}, TZ ${{ matrix.tz }})
     runs-on: ubuntu-latest
 
-    # Only the America/Chicago leg is allowed to fail, and only until #13 lands.
-    # See the matrix comment below.
-    continue-on-error: ${{ matrix.experimental }}
-
     strategy:
       # One failing leg must not cancel the others - the whole point of a matrix
       # is knowing which environments break, not just that one did.
@@ -27,21 +23,18 @@ jobs:
       matrix:
         node: [18, 20, 22, 24]
         tz: [UTC]
-        experimental: [false]
         include:
-          # Non-UTC leg. GitHub runners are UTC, which hid a real date-parsing
-          # defect for months: parseDate reads YYYY-MM-DD as UTC midnight and
-          # formats it with local getters, so date-only events render a day
-          # early at negative offsets. Locally: 55/55 pass under TZ=UTC,
-          # 54/55 under TZ=America/Chicago.
+          # Non-UTC leg, now blocking. GitHub runners are UTC, which hid a real
+          # date-parsing defect for months: parseDate read YYYY-MM-DD as UTC
+          # midnight and formatted it with local getters, so date-only events
+          # rendered a day early at negative offsets (#13).
           #
-          # This leg is EXPECTED TO FAIL until #13 is fixed. It is marked
-          # experimental so it reports red without blocking merges in the
-          # meantime. The #13 fix PR must delete this include entry's
-          # `experimental: true` so the leg becomes blocking.
+          # The defect is fixed and this leg passes, so it is a required check
+          # rather than an advisory one. Do not weaken it back to
+          # continue-on-error - a green UTC-only suite is exactly what let the
+          # original defect survive for eight months.
           - node: 20
             tz: America/Chicago
-            experimental: true
 
     env:
       TZ: ${{ matrix.tz }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,48 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - Unreleased
+
+### Fixed
+
+- **Date-only events no longer render one day early outside UTC.** `"2023-01-15"`
+  and other date-only strings were parsed as **UTC midnight** — per the ECMAScript
+  specification — and then read back with local-time getters. At any negative UTC
+  offset the calendar day shifted backwards by one, so an event written as
+  January 15 rendered as January 14 throughout the Americas. Date-only strings now
+  resolve to **local midnight**, so the day you write is the day that renders.
+
+  **This changes rendered output.** If you previously compensated by shifting your
+  data forward a day, remove that adjustment. Timelines built from date-only Simile
+  JSON will move by one day at negative offsets — to the correct day.
+
+  Unaffected: datetimes without an offset (`"2023-06-20T14:30:00"`, already local),
+  values with an explicit `Z` or `±HH:MM` suffix (still absolute instants), year-only
+  and BCE values, and legacy Simile formats. Native ISO bounds are preserved —
+  out-of-range months and days still fail, and in-range overflow such as
+  `"2023-02-29"` still rolls over.
+
+- The `centerDate` prop shared the same defect. String values were parsed with the
+  native constructor, so `centerDate="2023-01-15"` centered a day early at negative
+  offsets. String values now use the same parser as event dates, and an unparseable
+  string falls back to the median event date instead of producing an `Invalid Date`.
+
+### Changed
+
+- CI runs the unit suite under a non-UTC timezone as a required check. GitHub
+  runners are UTC, where this defect was invisible; the suite was red on any
+  developer machine west of Greenwich while CI stayed green.
+
 ## [1.0.2] - 2024-12-19
 
 ### Fixed
+
 - Include README.md in NPM package for proper display on npmjs.com
 
 ## [1.0.1] - 2024-12-19
 
 ### Changed
+
 - Enhanced README with feature table, code examples, and API reference for NPM
 
 ## [1.0.0] - 2024-12-19
@@ -20,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Core Features
+
 - `<Timeline>` component with configurable multi-band layout
 - Two-band and three-band timeline configurations
 - Band synchronization (linked scrolling between bands)
@@ -29,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Time scale rendering with automatic label formatting
 
 #### Event Rendering
+
 - Point events with dot markers and labels
 - Duration events with horizontal tape/bar rendering
 - Smart label layout engine (vertical stacking, overlap prevention)
@@ -38,17 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overview band with tick markers
 
 #### Hot Zones
+
 - Highlighted background regions for time periods
 - Hot zone text annotations
 - Customizable colors per zone
 
 #### Theming
+
 - Classic theme (default light theme)
 - Dark theme with CSS custom properties
 - Custom theme support via Theme object with CSS variable overrides
 - Smooth animated transitions between themes
 
 #### Navigation & Data
+
 - Event click handler with popup/details display
 - Jump-to-date navigation via `jumpToDate` action
 - Simile JSON data loading from URL (`dataUrl` prop)
@@ -57,17 +96,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Graceful error handling for invalid dates
 
 #### Accessibility
+
 - ARIA labels and roles for screen readers
 - Keyboard-accessible interactions
 - Focus management
 
 #### Other
+
 - Optional SIMILE-style branding/watermark
 - 100% backward compatibility with Simile JSON format
 - TypeScript types for all public APIs
 - CSS-only styling (no runtime dependencies)
 
 ### Performance
+
 - 60+ FPS smooth scrolling (verified at 120 FPS average)
 - Efficient virtualization for large event sets
 - Optimized re-renders with React hooks
@@ -75,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Planned
+
 - Zone magnification effect
 - Full WCAG 2.1 AA compliance
 - Visual regression testing

--- a/packages/react-simile-timeline/src/components/Timeline.tsx
+++ b/packages/react-simile-timeline/src/components/Timeline.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import type { TimelineProps, TimelineData, BrandingConfig } from '../types';
+import { tryParseDate } from '../utils/dateUtils';
 import { TimelineProvider, useTimelineContext } from './TimelineProvider';
 import { Band } from './Band';
 import { EventPopup } from './EventPopup';
@@ -273,9 +274,13 @@ export function Timeline({
   // Pass bands to provider - if undefined, provider will auto-generate based on data
   const bandConfigs = bands && bands.length > 0 ? bands : undefined;
 
-  // Parse initial center date
+  // Parse initial center date. String values go through tryParseDate rather
+  // than the native constructor: a date-only string parsed natively is UTC
+  // midnight and lands a day early at negative offsets. An unparseable value
+  // yields undefined so the timeline falls back to the median event date
+  // instead of centering on an Invalid Date.
   const initialCenterDate = centerDate
-    ? (centerDate instanceof Date ? centerDate : new Date(centerDate))
+    ? (centerDate instanceof Date ? centerDate : tryParseDate(centerDate) ?? undefined)
     : undefined;
 
   // Resolve branding config

--- a/packages/react-simile-timeline/src/components/TimelineProvider.tsx
+++ b/packages/react-simile-timeline/src/components/TimelineProvider.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from 'react';
 import type { TimelineEvent, BandConfig, HotZone } from '../types';
-import { getVisibleRange, getMedianDate, TIME_UNITS, type TimeUnit, parseDate } from '../utils/dateUtils';
+import { getVisibleRange, getMedianDate, TIME_UNITS, type TimeUnit, parseDate, tryParseDate } from '../utils/dateUtils';
 
 /**
  * Click position for popup positioning
@@ -230,6 +230,30 @@ export interface TimelineProviderProps {
 }
 
 /**
+ * Resolve a center date from props.
+ *
+ * String values go through tryParseDate rather than the native constructor:
+ * a date-only string parsed natively is UTC midnight and lands a day early
+ * at negative UTC offsets. An unparseable string falls back to the median
+ * event date rather than becoming an Invalid Date.
+ */
+function resolveCenterDate(
+  value: Date | string | undefined,
+  fallbackEvents: TimelineEvent[]
+): Date {
+  if (value) {
+    if (value instanceof Date) {
+      return value;
+    }
+    const parsed = tryParseDate(value);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return getMedianDate(fallbackEvents);
+}
+
+/**
  * Timeline context provider
  * Manages shared state for all timeline bands
  */
@@ -256,24 +280,15 @@ export function TimelineProvider({
   const pixelsPerMs = calculatePixelsPerMs(primaryBand);
 
   // Helper to compute center date from props
-  const computeCenterDate = useCallback(() => {
-    if (initialCenterDate) {
-      return initialCenterDate instanceof Date
-        ? initialCenterDate
-        : new Date(initialCenterDate);
-    }
-    return getMedianDate(events);
-  }, [initialCenterDate, events]);
+  const computeCenterDate = useCallback(
+    () => resolveCenterDate(initialCenterDate, events),
+    [initialCenterDate, events]
+  );
 
   // State - use lazy initialization for centerDate
-  const [centerDate, setCenterDateState] = useState<Date>(() => {
-    if (initialCenterDate) {
-      return initialCenterDate instanceof Date
-        ? initialCenterDate
-        : new Date(initialCenterDate);
-    }
-    return getMedianDate(events);
-  });
+  const [centerDate, setCenterDateState] = useState<Date>(() =>
+    resolveCenterDate(initialCenterDate, events)
+  );
   const [viewportWidth, setViewportWidth] = useState<number>(800);
   const [selectedEvent, setSelectedEventState] = useState<TimelineEvent | null>(null);
   const [clickPosition, setClickPosition] = useState<ClickPosition | null>(null);

--- a/packages/react-simile-timeline/src/utils/dateUtils.test.ts
+++ b/packages/react-simile-timeline/src/utils/dateUtils.test.ts
@@ -45,6 +45,79 @@ describe('parseDate', () => {
   });
 });
 
+// These assertions are timezone-sensitive by design. They pass under UTC and
+// must also pass at negative offsets, where the original defect appeared. CI
+// runs a TZ=America/Chicago leg specifically to exercise them.
+describe('parseDate - timezone handling', () => {
+  it('parses a date-only string as local midnight, not UTC midnight', () => {
+    const date = parseDate('2023-01-15');
+    expect(date.getFullYear()).toBe(2023);
+    expect(date.getMonth()).toBe(0);
+    expect(date.getDate()).toBe(15);
+    expect(date.getHours()).toBe(0);
+    expect(date.getMinutes()).toBe(0);
+    expect(date.getSeconds()).toBe(0);
+  });
+
+  it('keeps the written calendar day when formatted back (regression)', () => {
+    // The defect: "2023-01-15" parsed as UTC midnight, then read with local
+    // getters, formatted as "Jan 14, 2023" anywhere west of Greenwich.
+    expect(formatDate(parseDate('2023-01-15'), 'MMM d, yyyy')).toBe('Jan 15, 2023');
+  });
+
+  it('parses a year-month string as local midnight on the first', () => {
+    const date = parseDate('2023-06');
+    expect(date.getFullYear()).toBe(2023);
+    expect(date.getMonth()).toBe(5);
+    expect(date.getDate()).toBe(1);
+    expect(date.getHours()).toBe(0);
+  });
+
+  it('treats a datetime without an offset as local time', () => {
+    const date = parseDate('2023-06-20T14:30:00');
+    expect(date.getDate()).toBe(20);
+    expect(date.getHours()).toBe(14);
+    expect(date.getMinutes()).toBe(30);
+  });
+
+  it('honors an explicit Z suffix as an absolute instant', () => {
+    expect(parseDate('2023-06-20T14:30:00Z').getTime()).toBe(
+      Date.UTC(2023, 5, 20, 14, 30)
+    );
+  });
+
+  it('honors an explicit numeric offset as an absolute instant', () => {
+    expect(parseDate('2023-06-20T14:30:00+02:00').getTime()).toBe(
+      Date.UTC(2023, 5, 20, 12, 30)
+    );
+  });
+
+  it('does not remap years below 100 into the 1900s', () => {
+    expect(parseDate('0050-03-04').getFullYear()).toBe(50);
+  });
+
+  it('preserves native ISO bounds - month and day out of range still throw', () => {
+    expect(() => parseDate('2023-13-01')).toThrow('Unable to parse date');
+    expect(() => parseDate('2023-00-01')).toThrow('Unable to parse date');
+    expect(() => parseDate('2023-01-00')).toThrow('Unable to parse date');
+    expect(() => parseDate('2023-01-32')).toThrow('Unable to parse date');
+  });
+
+  it('preserves native rollover inside those bounds', () => {
+    // "2023-02-29" is not a real date; the native parser rolled it to
+    // March 1 and this must keep doing the same, just in local time.
+    const date = parseDate('2023-02-29');
+    expect(date.getMonth()).toBe(2);
+    expect(date.getDate()).toBe(1);
+  });
+
+  it('parses a real leap day without rolling over', () => {
+    const date = parseDate('2024-02-29');
+    expect(date.getMonth()).toBe(1);
+    expect(date.getDate()).toBe(29);
+  });
+});
+
 describe('formatDate', () => {
   const testDate = new Date(2023, 5, 15, 14, 30); // June 15, 2023 14:30
 
@@ -154,7 +227,11 @@ describe('getMedianDate', () => {
     ];
 
     const median = getMedianDate(events);
-    expect(median.getTime()).toBeCloseTo(new Date('2023-06-15').getTime(), -3);
+    // Expectation goes through parseDate, not new Date(). getMedianDate
+    // parses its inputs with parseDate, so a native-constructor expectation
+    // encodes UTC midnight and diverges from the result by the local offset
+    // everywhere except UTC.
+    expect(median.getTime()).toBeCloseTo(parseDate('2023-06-15').getTime(), -3);
   });
 
   it('returns average of middle dates for even number of events', () => {
@@ -166,9 +243,10 @@ describe('getMedianDate', () => {
     ];
 
     const median = getMedianDate(events);
-    // Average of March 1 and September 1
-    const mar1 = new Date('2023-03-01').getTime();
-    const sep1 = new Date('2023-09-01').getTime();
+    // Average of March 1 and September 1, parsed the same way getMedianDate
+    // parses them so the expectation holds in every timezone.
+    const mar1 = parseDate('2023-03-01').getTime();
+    const sep1 = parseDate('2023-09-01').getTime();
     const expectedMedian = (mar1 + sep1) / 2;
 
     expect(median.getTime()).toBeCloseTo(expectedMedian, -3);

--- a/packages/react-simile-timeline/src/utils/dateUtils.ts
+++ b/packages/react-simile-timeline/src/utils/dateUtils.ts
@@ -3,6 +3,45 @@
  * Supports ISO 8601, legacy Simile formats, year-only, and BCE dates
  */
 
+/** ISO 8601 calendar dates carrying no time component: "2023-01-15" or "2023-01". */
+const ISO_DATE_ONLY = /^(\d{4})-(\d{2})(?:-(\d{2}))?$/;
+
+/**
+ * Parse an ISO date-only string as local midnight.
+ *
+ * `new Date("2023-01-15")` is UTC midnight by specification, but every
+ * consumer of these values reads them with local getters, so parsing
+ * natively shifts date-only events one day earlier at negative UTC offsets.
+ *
+ * Native ISO bounds are reproduced exactly so this stays a timezone fix and
+ * nothing more: month must be 01-12 and day 01-31, while overflow inside
+ * those bounds still rolls over ("2023-02-29" -> March 1, as before).
+ *
+ * Returns null when the string is not a date-only form or is out of bounds,
+ * leaving the caller to fall through to the other formats.
+ */
+function parseIsoDateOnly(value: string): Date | null {
+  const match = value.match(ISO_DATE_ONLY);
+  if (!match) {
+    return null;
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = match[3] === undefined ? 1 : Number(match[3]);
+
+  if (month < 1 || month > 12 || day < 1 || day > 31) {
+    return null;
+  }
+
+  // Built via setFullYear rather than the constructor so years 0-99 are not
+  // remapped into the 1900s.
+  const date = new Date(0);
+  date.setFullYear(year, month - 1, day);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
 /**
  * Parse a date string into a Date object
  * Supports multiple formats for Simile compatibility:
@@ -10,6 +49,13 @@
  * - Legacy: "Jan 15 2023", "January 15, 2023"
  * - Year only: "2023"
  * - BCE: "-500" (500 BCE)
+ *
+ * Timezone semantics:
+ * - Date-only strings ("2023-01-15", "2023-01") resolve to local midnight,
+ *   so the calendar day a caller wrote is the calendar day rendered.
+ * - Datetimes without an offset ("2023-06-20T14:30:00") are local, per spec.
+ * - An explicit "Z" or "+/-HH:MM" suffix is honored as an absolute instant,
+ *   because the caller chose that deliberately.
  */
 export function parseDate(dateStr: string): Date {
   if (!dateStr) {
@@ -26,6 +72,13 @@ export function parseDate(dateStr: string): Date {
     date.setFullYear(year, 0, 1);
     date.setHours(0, 0, 0, 0);
     return date;
+  }
+
+  // Date-only strings must be built locally, before the native parser gets
+  // them and interprets them as UTC.
+  const dateOnly = parseIsoDateOnly(trimmed);
+  if (dateOnly) {
+    return dateOnly;
   }
 
   // Try ISO 8601 first (most common)


### PR DESCRIPTION
Closes #13. The P0 in milestone `v1.0.3` — the highest-impact defect in the repository.

## The defect

`parseDate` handed `"2023-01-15"` to the native `Date` constructor. Per the ECMAScript spec the **date-only form is UTC midnight**, but every consumer of the result — `formatDate`, the layout engine, the scales — reads it back with **local** getters.

```
new Date('2023-01-15')  ->  Sat Jan 14 2023 18:00:00 GMT-0600
getDate()               ->  14
```

`YYYY-MM-DD` is the dominant format in Simile JSON, so **every date-only event rendered one day early across the Americas**.

## The fix

Date-only strings are built as local midnight. Native ISO semantics are reproduced exactly, so this stays a timezone fix and nothing more:

| Input | Before | After |
|---|---|---|
| `2023-01-15` | UTC midnight → Jan 14 local | **local midnight → Jan 15** |
| `2023-13-01`, `2023-01-32` | throws | throws (unchanged) |
| `2023-02-29` | rolls to Mar 1 | rolls to Mar 1 (unchanged) |
| `0050-03-04` | year 50 | year 50, not 1950 |

Construction goes through `setFullYear` rather than the constructor so years 0–99 aren't remapped into the 1900s.

**Deliberately unchanged:** datetimes without an offset (`"2023-06-20T14:30:00"`) are already local per spec; values with `Z` or `±HH:MM` are absolute instants the caller chose on purpose.

## Scope beyond the issue: `centerDate` had the same bug

`centerDate?: string | Date` is a **public prop**, and three sites parsed the string form with the native constructor — so `centerDate="2023-01-15"` centred a day early too. Same root cause, so fixing `parseDate` alone would have left the public API broken.

All three now route through `tryParseDate`. Bonus: an unparseable string falls back to the median event date instead of producing an `Invalid Date`.

## Two pre-existing tests encoded the bug

`getMedianDate` tests compared against `new Date('2023-06-15')` while the code under test uses `parseDate`. They agreed **only under UTC** and diverged by exactly the local offset elsewhere. Expectations now use `parseDate`, so they hold everywhere.

Worth noting: these did not fail before this PR — they were latent, and only surfaced once the source was corrected.

## The CI leg is now blocking

`continue-on-error` is **removed** from the `America/Chicago` leg. It was advisory only because it was expected to fail. The defect is fixed, so it's a required check.

The workflow comment now says explicitly not to weaken it back — a green UTC-only suite is exactly what let this survive eight months.

**#7 can now add `build-and-test (node 20, TZ America/Chicago)` to the required checks.**

## Verification

65/65 tests across six timezones spanning negative, positive, half-hour and +14 offsets:

| Timezone | Offset | Result |
|---|---|---|
| `UTC` | +00:00 | 65/65 |
| `America/Chicago` | −05:00 | 65/65 |
| `America/Anchorage` | −08:00 | 65/65 |
| `Asia/Tokyo` | +09:00 | 65/65 |
| `Pacific/Kiritimati` | +14:00 | 65/65 |
| `Australia/Eucla` | +08:45 | 65/65 |

10 new tests. `pnpm lint` clean (0 errors), `typecheck` clean, library and demo both build.

## Breaking-ish behavior note

This **changes rendered output** for existing users at negative offsets — their events shift one day, to the correct day. Anyone who compensated by shifting data forward must remove that adjustment. Called out prominently in the CHANGELOG. Patch version is correct semver for a bug fix, per the decision recorded when the backlog was filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)