### PR TITLE
docs: point the Live Demo links at the deployment that exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 
 <p align="center">
   <strong>
-    <a href="https://react-simile-timeline.vercel.app/">Live Demo</a> •
+    <a href="https://react-simile-timeline-demo.vercel.app/">Live Demo</a> •
     <a href="#installation">Installation</a> •
     <a href="#quick-start">Quick Start</a> •
     <a href="#api-reference">API</a> •
@@ -269,7 +269,7 @@ MIT License - see [LICENSE](https://github.com/thbst16/react-simile-timeline/blo
 
 ## Links
 
-- [Live Demo](https://react-simile-timeline.vercel.app/)
+- [Live Demo](https://react-simile-timeline-demo.vercel.app/)
 - [GitHub Repository](https://github.com/thbst16/react-simile-timeline)
 - [Issue Tracker](https://github.com/thbst16/react-simile-timeline/issues)
 - [Changelog](https://github.com/thbst16/react-simile-timeline/blob/main/CHANGELOG.md)

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -10,7 +10,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 
 <p align="center">
   <strong>
-    <a href="https://react-simile-timeline.vercel.app/">Live Demo</a> •
+    <a href="https://react-simile-timeline-demo.vercel.app/">Live Demo</a> •
     <a href="#installation">Installation</a> •
     <a href="#quick-start">Quick Start</a> •
     <a href="#api-reference">API</a> •
@@ -269,7 +269,7 @@ MIT License - see [LICENSE](https://github.com/thbst16/react-simile-timeline/blo
 
 ## Links
 
-- [Live Demo](https://react-simile-timeline.vercel.app/)
+- [Live Demo](https://react-simile-timeline-demo.vercel.app/)
 - [GitHub Repository](https://github.com/thbst16/react-simile-timeline)
 - [Issue Tracker](https://github.com/thbst16/react-simile-timeline/issues)
 - [Changelog](https://github.com/thbst16/react-simile-timeline/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Closes #15.

Both `Live Demo` links pointed at `https://react-simile-timeline.vercel.app/`, which returns **404**. The live deployment is `https://react-simile-timeline-demo.vercel.app/` (200), already correct in the repository `homepageUrl`.

### Fixed in both READMEs

`README.md` and `packages/react-simile-timeline/README.md` are byte-identical, and the package copy is the one that ships in the npm tarball and renders on npmjs.com. Fixing only the root README would have left the dead link in front of every consumer, so both are corrected.

### Every other outbound link verified

| Status | Link |
| --- | --- |
| 200 | github.com/thbst16/react-simile-timeline (+ actions, issues, blob/main CONTRIBUTING, LICENSE, CHANGELOG) |
| 200 | shields.io badges (4) |
| 200 | opensource.org/licenses/MIT |
| 200 | simile-widgets.org/timeline |
| 200 | typescriptlang.org |
| 403 | npmjs.com/package/react-simile-timeline — bot protection on scripted requests; resolves in a browser |
| 200 | react-simile-timeline-demo.vercel.app (was 404 as react-simile-timeline.vercel.app) |

Documentation only.