### PR TITLE
docs: correct CHANGELOG dates, the TypeScript badge, and the perf claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,19 +37,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   runners are UTC, where this defect was invisible; the suite was red on any
   developer machine west of Greenwich while CI stayed green.
 
-## [1.0.2] - 2024-12-19
+## [1.0.2] - 2025-12-19
 
 ### Fixed
 
 - Include README.md in NPM package for proper display on npmjs.com
 
-## [1.0.1] - 2024-12-19
+## [1.0.1] - 2025-12-19
 
 ### Changed
 
 - Enhanced README with feature table, code examples, and API reference for NPM
 
-## [1.0.0] - 2024-12-19
+## [1.0.0] - 2025-11-16
+
+> **Not installable from npm.** `1.0.0` was published and then unpublished, and
+> npm permanently blocks republishing an unpublished version. Use `1.0.1` or
+> later. The tag and GitHub release remain as history.
 
 ### Added
 
@@ -111,7 +115,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - 60+ FPS smooth scrolling (verified at 120 FPS average)
-- Efficient virtualization for large event sets
+- Viewport culling — only events inside the visible date range are rendered, so
+  the rendered node count is bounded by the viewport rather than by the size of
+  the dataset
 - Optimized re-renders with React hooks
 
 ## [Unreleased]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/react-simile-timeline.svg)](https://www.npmjs.com/package/react-simile-timeline)
 [![npm downloads](https://img.shields.io/npm/dm/react-simile-timeline.svg)](https://www.npmjs.com/package/react-simile-timeline)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/github/package-json/dependency-version/thbst16/react-simile-timeline/dev/typescript?label=TypeScript&color=blue)](https://www.typescriptlang.org/)
 
 A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-widgets.org/timeline/) visualization component. Build beautiful, interactive timelines with ease.
 

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/react-simile-timeline.svg)](https://www.npmjs.com/package/react-simile-timeline)
 [![npm downloads](https://img.shields.io/npm/dm/react-simile-timeline.svg)](https://www.npmjs.com/package/react-simile-timeline)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.0-blue.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/github/package-json/dependency-version/thbst16/react-simile-timeline/dev/typescript?label=TypeScript&color=blue)](https://www.typescriptlang.org/)
 
 A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-widgets.org/timeline/) visualization component. Build beautiful, interactive timelines with ease.
 


### PR DESCRIPTION
Closes #16.

Three of the four items in the issue. The fourth — the note on the **v1.0.0 GitHub release** — is owner-applied and deliberately left for the maintainer.

---

### 1. CHANGELOG release dates

All three entries read `2024-12-19`. Measured against both sources of truth:

```
$ npm view react-simile-timeline time --json
  "1.0.0": "2025-11-16T20:16:15.342Z"
  "1.0.1": "2025-12-19T01:40:45.217Z"
  "1.0.2": "2025-12-19T01:42:59.851Z"

$ git log -1 --format=%cI v1.0.0   ->  2025-11-16T14:20:57-06:00
$ git log -1 --format=%cI v1.0.1   ->  2025-12-19T01:40:02Z
$ git log -1 --format=%cI v1.0.2   ->  2025-12-19T01:42:20Z
```

> **Deviation worth a look.** The plan and the issue both say to move all three to `2025-12-19`. That is right for `1.0.1` and `1.0.2`, but `1.0.0` shipped a **month earlier**, on `2025-11-16` — npm and the git tag agree independently. Writing `2025-12-19` there would have put a knowingly wrong date into the commit whose whole purpose is fixing wrong dates, so each entry carries its measured date instead. Reverting `1.0.0` to `2025-12-19` is a one-line change if the maintainer prefers the uniform date.

The `1.0.0` entry also gains a short note that the version is permanently uninstallable from npm and that readers should use `1.0.1`+. That is the same fact as the GitHub release note, on the surface consumers actually read. It does not substitute for the release note.

### 2. TypeScript badge

Hardcoded at `5.0` while the toolchain resolves `5.9.3`. Replaced with the shields.io endpoint that reads the declared range out of `package.json`, so it cannot drift again:

```
https://img.shields.io/github/package-json/dependency-version/thbst16/react-simile-timeline/dev/typescript?label=TypeScript&color=blue
```

Verified live — returns `200`, renders `TypeScript: ^5.4.0`. Changed in both READMEs.

### 3. "Efficient virtualization for large event sets"

The claim lives in the `1.0.0` CHANGELOG entry, not the README. Checked against the implementation rather than removed on suspicion, and it turns out to be **half true**.

**True:** `filterVisibleEvents` culls to the visible range plus a buffer, in the detail band and the overview band both. Rendered node count is bounded by the viewport.

**Not true:** it is a full linear scan with a `parseDate` per event on every layout pass, and the `useMemo` keys on values that change on every pan, so the memo never hits during interaction. Measured against the built bundle, 1200px viewport at 100px/day:

| Events | Rendered nodes | ms per layout pass |
| ---: | ---: | ---: |
| 100 | 1 | 0.10 |
| 1,000 | 1 | 0.54 |
| 10,000 | 3 | 4.00 |
| 50,000 | 11 | 18.03 |

Node count flat, time linear. The entry now claims the culling and drops the efficiency. The linear scan is filed as #36 — it is real, but it is not `v1.0.3` work.

---

Also filed in passing: #37, the two READMEs being byte-identical duplicates with nothing keeping them in sync.

Documentation only. No library, workflow, or packaging change.