### PR TITLE
release: add npm provenance and a tag/version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The tag is the only trigger for this workflow, and publishing is
+      # irreversible - npm's unpublish window is narrow and using it permanently
+      # burns the version number. That is how 1.0.0 was lost on this package.
+      # A tag that disagrees with package.json is one way to repeat it, so it
+      # fails here, in seconds, before anything is built or pushed anywhere.
+      - name: Verify tag matches package version
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          pkg="v$(node -p "require('./packages/react-simile-timeline/package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag ${tag} does not match package.json version ${pkg}. Nothing published."
+            exit 1
+          fi
+          echo "Tag ${tag} matches package.json version ${pkg}."
+
       # No `version:` input - read from `packageManager` in package.json.
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -32,6 +48,19 @@ jobs:
       - name: Build library
         run: pnpm build:lib
 
+      # Provenance is switched on through `publishConfig.provenance` in the
+      # package's package.json, NOT through a `--provenance` flag here.
+      #
+      # `pnpm --filter <pkg> publish` takes pnpm's recursive publish path, and
+      # on the pinned pnpm (9.0.0) that path discards the invoking argv and
+      # rebuilds the npm command from scratch: it forwards only --access,
+      # --dry-run and --otp. A `--provenance` flag on this line would be
+      # accepted by the CLI, silently dropped, and produce an unattested
+      # release that looks like it worked. `publishConfig` travels inside the
+      # packed tarball's manifest instead, so npm reads it whichever path pnpm
+      # takes. Verified: the field is present in the packed package.json.
+      #
+      # `id-token: write` above is what lets npm mint the attestation.
       - name: Publish to NPM
         run: pnpm --filter react-simile-timeline publish --no-git-checks
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,48 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dry check of the NPM_TOKEN secret. Selects the verify-token job
+  # only - it can never publish. See the job guards below.
+  workflow_dispatch:
 
 jobs:
+  # There is no way to confirm the publish credential short of using it, and
+  # using it for real is the irreversible step. This job answers "is the token
+  # still good?" with a whoami and nothing else: no build, no pack, no publish.
+  #
+  # Run it from the Actions tab before pushing a release tag. A dead token
+  # discovered here costs nothing; discovered after tagging it costs a version
+  # number, because the tag is consumed whether or not the publish succeeds.
+  verify-token:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Check NPM_TOKEN against the registry
+        run: |
+          set -euo pipefail
+          if ! who=$(npm whoami 2>&1); then
+            echo "::error::NPM_TOKEN is not accepted by the registry. Do not push a release tag until it is replaced."
+            echo "$who"
+            exit 1
+          fi
+          echo "NPM_TOKEN authenticates as: ${who}"
+          echo "Publish rights are a separate question - confirm this account can publish react-simile-timeline."
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish:
+    # Belt and braces: this job runs for a pushed tag and nothing else, so a
+    # manual dispatch cannot reach the publish step however the triggers change.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offsets. String values now use the same parser as event dates, and an unparseable
   string falls back to the median event date instead of producing an `Invalid Date`.
 
+### Added
+
+- **The published package carries npm provenance.** Releases are now attested,
+  giving a verifiable link between the tarball on npm and the workflow run and
+  commit that built it. Check it with
+  `npm view react-simile-timeline dist.attestations`.
+
 ### Changed
 
 - CI runs the unit suite under a non-UTC timezone as a required check. GitHub
   runners are UTC, where this defect was invisible; the suite was red on any
   developer machine west of Greenwich while CI stayed green.
+- The release workflow refuses to publish when the pushed tag does not match
+  the version in `package.json`.
+- Documentation corrections: both `Live Demo` links pointed at a host that
+  returned 404; the CHANGELOG release dates for `1.0.0`–`1.0.2` were a year
+  early; the TypeScript badge was pinned to a version the project had long
+  since left; and the README's size claim did not distinguish the ~12 KB that
+  reaches your users from the ~404 KB installed on disk.
 
 ## [1.0.2] - 2025-12-19
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 | **Multi-Band** | Two-band, three-band, or custom configurations |
 | **Fully Themeable** | Classic, dark, and custom themes via CSS variables |
 | **Accessible** | ARIA labels, keyboard navigation, screen reader support |
-| **Lightweight** | ~12KB gzipped, zero runtime dependencies |
+| **Lightweight** | ~12KB gzipped in your bundle, zero runtime dependencies |
 
 ---
 
@@ -47,6 +47,17 @@ yarn add react-simile-timeline
 ```bash
 pnpm add react-simile-timeline
 ```
+
+### Package size
+
+Two different numbers, often confused:
+
+| Measure | Size | What it is |
+|---------|------|------------|
+| **Shipped to your users** | **~12 KB gzipped** | The ESM bundle (11.5 KB gzipped) plus the stylesheet (1.1 KB gzipped), after your bundler and your server's compression |
+| Installed in `node_modules` | ~404 KB | The whole published package on disk, including both builds, both type declarations, and sourcemaps |
+
+Sourcemaps are 271 KB of that 404 KB. They are shipped deliberately, so you can step into library source when debugging, and they are never sent to a browser unless devtools asks for them. They do not reach your users and do not count against your bundle.
 
 ---
 

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -30,7 +30,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 | **Multi-Band** | Two-band, three-band, or custom configurations |
 | **Fully Themeable** | Classic, dark, and custom themes via CSS variables |
 | **Accessible** | ARIA labels, keyboard navigation, screen reader support |
-| **Lightweight** | ~12KB gzipped, zero runtime dependencies |
+| **Lightweight** | ~12KB gzipped in your bundle, zero runtime dependencies |
 
 ---
 
@@ -47,6 +47,17 @@ yarn add react-simile-timeline
 ```bash
 pnpm add react-simile-timeline
 ```
+
+### Package size
+
+Two different numbers, often confused:
+
+| Measure | Size | What it is |
+|---------|------|------------|
+| **Shipped to your users** | **~12 KB gzipped** | The ESM bundle (11.5 KB gzipped) plus the stylesheet (1.1 KB gzipped), after your bundler and your server's compression |
+| Installed in `node_modules` | ~404 KB | The whole published package on disk, including both builds, both type declarations, and sourcemaps |
+
+Sourcemaps are 271 KB of that 404 KB. They are shipped deliberately, so you can step into library source when debugging, and they are never sent to a browser unless devtools asks for them. They do not reach your users and do not count against your bundle.
 
 ---
 

--- a/packages/react-simile-timeline/package.json
+++ b/packages/react-simile-timeline/package.json
@@ -87,6 +87,7 @@
     "node": ">=18.0.0"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
Closes #17.

---

## 1. Provenance — and why it is not the `--provenance` flag

The plan called this "a one-flag change". It is not, on the pinned pnpm.

`pnpm --filter react-simile-timeline publish` takes pnpm's **recursive publish** path. In pnpm `9.0.0` — the version pinned by `packageManager` and therefore the version `pnpm/action-setup@v4` installs — that path throws away the invoking argv and rebuilds the npm command from scratch:

```js
// pnpm 9.0.0, recursivePublish
const appendedArgs = []
if (opts.cliOptions['access']) appendedArgs.push(`--access=${opts.cliOptions['access']}`)
if (opts.dryRun)              appendedArgs.push('--dry-run')
if (opts.cliOptions['otp'])   appendedArgs.push(`--otp=${opts.cliOptions['otp']}`)
...
argv: { original: ['publish', '--tag', tag, '--registry', registry, ...appendedArgs] }
```

Only `--access`, `--dry-run` and `--otp` are forwarded. `--provenance` is a **recognized** pnpm option — it is in `rcOptionsTypes`, and passing it does not error — so `pnpm --filter … publish --provenance` would have exited 0, published successfully, and produced **no attestation**. A silent no-op is the worst available outcome here, since the whole point is a check someone will later rely on.

So provenance is set through `publishConfig` in the package manifest instead:

```json
"publishConfig": { "access": "public", "provenance": true }
```

`publishConfig` travels inside the packed tarball's `package.json`, and npm flattens it into publish options whichever way pnpm invokes it. Verified by packing and reading it back:

```
$ pnpm pack --pack-destination <tmp>
$ tar -xzOf <tmp>/*.tgz package/package.json | jq .publishConfig
{ "access": "public", "provenance": true }
```

`id-token: write` was already granted, so nothing else was needed.

**One consequence worth knowing:** this applies to *any* publish of the package, not just CI. A local `pnpm publish` from a workstation will now fail on provenance generation instead of quietly shipping an unattested build. That is the intent, but it will surprise whoever hits it.

## 2. Tag/version guard

The tag is this workflow's only trigger, and publishing is effectively irreversible. A mismatched tag is one route to burning a version number, which is exactly what happened to `1.0.0`. The check runs immediately after checkout — before install, before build, before any credential is used:

```yaml
- name: Verify tag matches package version
```

Exercised locally against the real manifest:

| `GITHUB_REF_NAME` | package.json | Result |
| --- | --- | --- |
| `v1.0.2` | `1.0.2` | pass, exit 0 |
| `v1.0.3` | `1.0.2` | fail, exit 1, `::error::Tag v1.0.3 does not match package.json version v1.0.2. Nothing published.` |
| `1.0.2` (no `v`) | `1.0.2` | fail, exit 1 |

## 3. Sourcemaps — kept, README corrected

Per the §3.2 decision, **option B**: the maps stay, the claim gets fixed. The README advertised "~12KB gzipped" without distinguishing bundle size from install footprint. Measured from an actual pack:

| | Bytes | |
| --- | ---: | --- |
| `dist/index.js` gzipped | 11,737 | reaches users |
| `dist/style.css` gzipped | 1,084 | reaches users |
| `dist/index.js.map` + `dist/index.cjs.map` | 271,336 | 67% of unpacked, reaches nobody |
| Tarball, packed | 107,256 | |
| Tarball, unpacked | 403,883 | |

Both READMEs now carry a **Package size** table separating the ~12 KB shipped to users from the ~404 KB installed in `node_modules`, and say why the maps are there.

## 4. CHANGELOG

The `1.0.3` entry gains the provenance addition, the tag guard, and a one-line summary of the documentation corrections from #15 and #16.

---

### Gates

`pnpm lint`, `pnpm build:lib`, `pnpm typecheck`, `pnpm --filter react-simile-timeline check:exports` all pass; suite green under `TZ=UTC` and `TZ=America/Chicago` (65 tests each).

**This PR cannot fully self-verify.** Provenance only proves itself on a real publish, which cannot happen before the tag is pushed. What has been verified is everything short of that: the field is in the packed manifest, npm reads `publishConfig.provenance` into publish options, and pnpm's pack path preserves it. The attestation itself must be checked after release with `npm view react-simile-timeline@1.0.3 dist.attestations`.