### PR TITLE
release: 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.3] - Unreleased
+## [1.0.3] - 2026-08-17
 
 ### Fixed
 

--- a/packages/react-simile-timeline/package.json
+++ b/packages/react-simile-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simile-timeline",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A modern React implementation of the MIT SIMILE Timeline visualization component. Create interactive, multi-band timelines with point and duration events, hot zones, themes, and 100% Simile JSON compatibility.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
The last PR of the `v1.0.3 - Critical fixes` milestone. Sets `packages/react-simile-timeline/package.json` to `1.0.3` and dates the CHANGELOG entry `2026-08-17`.

> ## Do not push the tag yet — `NPM_TOKEN` is dead
>
> The `verify-token` job added in #39 was run against `main` ([run 32058641435](https://github.com/thbst16/react-simile-timeline/actions/runs/32058641435)) and the registry rejected the credential:
>
> ```
> npm error code E401
> npm error 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
> ```
>
> `E401` rather than `ENEEDAUTH` means a bearer token **was** sent and the registry refused it — the secret exists and is invalid, not missing. `actions/setup-node` wrote the `.npmrc` correctly (npm 10.8.2, `registry-url` set), so this is not a workflow defect. The secret was created `2025-11-09` and last succeeded `2025-12-19`.
>
> Pushing `v1.0.3` against this token consumes the tag and the version number for a publish that will fail. Replace the secret first, re-run `verify-token`, and only then tag.

## Preflight results (§4.1)

| Check | Result |
| --- | --- |
| `NPM_TOKEN` valid | **FAIL — E401.** Blocks the tag push |
| `pnpm publish` provenance on the pinned pnpm | Resolved — pnpm 9.0.0 drops `--provenance` on the `--filter` path, so it goes through `publishConfig` (#39) |
| All 8 required checks green on `main` | Green after every merge in the milestone |
| `attw` clean | Green — node10, node16 from CJS, node16 from ESM, bundler |
| `dist/index.d.cts` in a fresh pack | Present, 19,916 bytes |

## Fresh pack of this branch

```
$ pnpm pack
react-simile-timeline-1.0.3.tgz          11 files
  version           1.0.3
  publishConfig     { "access": "public", "provenance": true }
  dist/index.d.cts  19,916   <- absent in 1.0.2; the #14 fix reaching consumers
  dist/index.js.map 138,589  \  kept deliberately per the §3.2 decision,
  dist/index.cjs.map 132,747 /  README size claim corrected instead
```

## Gates

`pnpm lint`, `pnpm build:lib`, `pnpm typecheck`, `pnpm --filter react-simile-timeline check:exports` all pass. Suite green under `TZ=UTC` and `TZ=America/Chicago`, 65 tests each.

## Still owner-applied after this merges

1. Replace `NPM_TOKEN`, then re-run the `verify-token` job
2. Add the note to the **v1.0.0 GitHub release** (§2.2) — uninstallable from npm, direct users to `1.0.1`+
3. Push `v1.0.3`