### PR TITLE
docs: describe the accessibility that exists, not a conformance level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,5 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Planned
 
 - Zone magnification effect
-- Full WCAG 2.1 AA compliance
+- Full WCAG 2.1 AA compliance ([#25](https://github.com/thbst16/react-simile-timeline/issues/25))
+  — audit and remediation. Until that lands, the project describes what is
+  implemented rather than asserting a conformance level.
 - Visual regression testing

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 | **Modern Stack** | Built with React 18/19, TypeScript, and hooks |
 | **Multi-Band** | Two-band, three-band, or custom configurations |
 | **Fully Themeable** | Classic, dark, and custom themes via CSS variables |
-| **Accessible** | ARIA labels, keyboard navigation, screen reader support |
+| **Accessible** | Keyboard navigation, focus management, ARIA labels on events and popups |
 | **Lightweight** | ~12KB gzipped in your bundle, zero runtime dependencies |
 
 ---

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -29,7 +29,7 @@ A modern React implementation of the [MIT SIMILE Timeline](https://www.simile-wi
 | **Modern Stack** | Built with React 18/19, TypeScript, and hooks |
 | **Multi-Band** | Two-band, three-band, or custom configurations |
 | **Fully Themeable** | Classic, dark, and custom themes via CSS variables |
-| **Accessible** | ARIA labels, keyboard navigation, screen reader support |
+| **Accessible** | Keyboard navigation, focus management, ARIA labels on events and popups |
 | **Lightweight** | ~12KB gzipped in your bundle, zero runtime dependencies |
 
 ---


### PR DESCRIPTION
Closes #24. Executes §6.1 of the [v1.1.0 plan](https://github.com/thbst16/react-simile-timeline/blob/main/plans/2026-08-18-toolchain-modernization-plan.md).

The repository asserted **"WCAG 2.1 AA accessible"** in its description while the CHANGELOG listed **"Full WCAG 2.1 AA compliance"** under *Planned* — the same conformance claimed as shipped and pending at once.

## The claim does not survive measurement

14 `aria-*` / `role=` usages, in **three** components:

| Component | ARIA usages |
| --- | ---: |
| `EventMarker` | 6 |
| `EventPopup` | 5 |
| `Timeline` | 3 |
| `Band`, `EventTrack`, `HotZones`, `OverviewMarkers`, `TimeScale`, `TimelineProvider` | **0** |

Six of nine components have none. That is consistent with basic ARIA support and not with audited AA conformance.

> **Correction to #24.** The issue records the 14 usages as spread "across 10 components". They sit in three. The correction cuts against the claim, not for it — two-thirds of the component surface is untouched.

## Changes

| Surface | Before | After |
| --- | --- | --- |
| Repository description | "TypeScript, **WCAG 2.1 AA accessible**, touch-enabled, 60fps performance" | "TypeScript, **keyboard navigable with ARIA labels**, touch-enabled, 60fps performance" |
| README feature row | "ARIA labels, keyboard navigation, screen reader support" | "Keyboard navigation, focus management, ARIA labels on events and popups" |
| CHANGELOG *Planned* | "Full WCAG 2.1 AA compliance" | Unchanged, now linking #25 and noting the project describes what is implemented until the audit lands |

The repository description is a GitHub setting with no PR form — **already applied**, since the plan marks it owner-applied and it was authorized by name. The description also lost a stray double space.

The README row is changed in **both** copies; the package one is what renders on npmjs.com.

## Deliberately not changed

- **`60fps performance`** in the description. #36 already qualifies that claim and its acceptance criteria include re-checking the README against the new numbers. Editing it here would pull #36's work forward into a documentation PR.
- **The `accessibility` repository topic.** A topic is a subject tag, not a conformance assertion.
- **The audit itself** is #25 and is deliberately outside this milestone.

## Verification

```
$ grep -rn "WCAG" README.md packages/react-simile-timeline/README.md packages/react-simile-timeline/package.json
no WCAG claim in README or package metadata

$ gh repo view --json description -q .description
Modern React timeline component based on MIT's Simile Timeline. TypeScript,
keyboard navigable with ARIA labels, touch-enabled, 60fps performance.
Compatible with original Simile JSON format.
```

The only surviving `WCAG` reference is the CHANGELOG's *Planned* entry, which is intended.

Documentation only. No library, workflow, or packaging change.