### PR TITLE
docs: reconcile the toolchain plan with what actually shipped

### DIFF
--- a/plans/2026-08-18-toolchain-modernization-plan.md
+++ b/plans/2026-08-18-toolchain-modernization-plan.md
@@ -13,26 +13,26 @@ Measured 2026-08-18 at `main@a1d9cd9`, immediately after the `1.0.3` release.
 
 ### Dependency lag
 
-| Package | Pinned | Current | Majors behind | Issue |
-| --- | --- | --- | ---: | --- |
-| `typescript` | 5.9.3 | 7.0.2 | 2 | #21 |
-| `vite` | 5.4.21 | 8.2.1 | 3 | #18 |
-| `vite-plugin-dts` | 3.9.1 | 5.0.3 | 2 | #18 |
-| `@vitejs/plugin-react` | 4.7.0 | 6.0.5 | 2 | **untracked** |
-| `vitest` | 1.6.1 | 4.1.10 | 3 | #19 |
-| `jsdom` | 24.1.3 | 30.0.1 | 6 | #19 |
-| `eslint` | 8.57.1 | 10.8.1 | 2 | #20 |
-| `@typescript-eslint/*` | 7.18.0 | 8.67.0 | 1 | #20 |
-| `eslint-plugin-react-hooks` | 4.6.2 | 7.1.1 | 3 | #20 |
-| `eslint-config-prettier` | 9.1.2 | 10.1.8 | 1 | #20 |
-| `@types/react` | 18.3.27 | 19.2.18 | 1 | #21 |
-| `@types/react-dom` | 18.3.7 | 19.2.4 | 1 | #21 |
-| `@testing-library/react` | 14.3.1 | 16.3.2 | 2 | #21 |
-| `@testing-library/jest-dom` | 6.9.1 | 7.0.1 | 1 | #21 |
-| `@types/node` | 20.19.27 | 26.2.0 | 6 | #21 |
-| `tailwindcss` (demo) | 3.4.19 | 4.3.3 | 1 | **untracked** |
-| `@playwright/test` (demo) | 1.57.0 | 1.62.1 | 0 | — |
-| `eslint-plugin-react` | 7.37.5 | 7.37.5 | 0 | — |
+| Package                     | Pinned   | Current | Majors behind | Issue         |
+| --------------------------- | -------- | ------- | ------------: | ------------- |
+| `typescript`                | 5.9.3    | 7.0.2   |             2 | #21           |
+| `vite`                      | 5.4.21   | 8.2.1   |             3 | #18           |
+| `vite-plugin-dts`           | 3.9.1    | 5.0.3   |             2 | #18           |
+| `@vitejs/plugin-react`      | 4.7.0    | 6.0.5   |             2 | **untracked** |
+| `vitest`                    | 1.6.1    | 4.1.10  |             3 | #19           |
+| `jsdom`                     | 24.1.3   | 30.0.1  |             6 | #19           |
+| `eslint`                    | 8.57.1   | 10.8.1  |             2 | #20           |
+| `@typescript-eslint/*`      | 7.18.0   | 8.67.0  |             1 | #20           |
+| `eslint-plugin-react-hooks` | 4.6.2    | 7.1.1   |             3 | #20           |
+| `eslint-config-prettier`    | 9.1.2    | 10.1.8  |             1 | #20           |
+| `@types/react`              | 18.3.27  | 19.2.18 |             1 | #21           |
+| `@types/react-dom`          | 18.3.7   | 19.2.4  |             1 | #21           |
+| `@testing-library/react`    | 14.3.1   | 16.3.2  |             2 | #21           |
+| `@testing-library/jest-dom` | 6.9.1    | 7.0.1   |             1 | #21           |
+| `@types/node`               | 20.19.27 | 26.2.0  |             6 | #21           |
+| `tailwindcss` (demo)        | 3.4.19   | 4.3.3   |             1 | **untracked** |
+| `@playwright/test` (demo)   | 1.57.0   | 1.62.1  |             0 | —             |
+| `eslint-plugin-react`       | 7.37.5   | 7.37.5  |             0 | —             |
 
 **Two majors are in the tree that no issue covers.** `@vitejs/plugin-react` is coupled to the Vite upgrade and must move with it; `tailwindcss` belongs to the demo and moves independently. Both are folded into this plan rather than discovered mid-migration.
 
@@ -40,29 +40,29 @@ Measured 2026-08-18 at `main@a1d9cd9`, immediately after the `1.0.3` release.
 
 **42 open across the two scanners**, which is the number the repository's Security tab reports:
 
-| Source | Open | Covered by |
-| --- | ---: | --- |
-| Dependabot advisories | 40 | §1, §2, §3 |
-| CodeQL code scanning | 2 | §6.5 |
+| Source                | Open | Covered by |
+| --------------------- | ---: | ---------- |
+| Dependabot advisories |   40 | §1, §2, §3 |
+| CodeQL code scanning  |    2 | §6.5       |
 
 #### Dependabot: 40
 
 Up from the 30 recorded in the `v1.0.3` plan five days earlier. All are dev-only — the published package has no runtime dependencies, so no consumer is exposed. The exposure is to CI and to anyone running the suite.
 
 | Severity | Count |
-| --- | ---: |
-| Critical | 2 |
-| High | 21 |
-| Medium | 16 |
-| Low | 1 |
+| -------- | ----: |
+| Critical |     2 |
+| High     |    21 |
+| Medium   |    16 |
+| Low      |     1 |
 
 Every advisory traces to one of three upgrades. The mapping matters, because it decides the execution order:
 
-| Cleared by | Alerts | Packages |
-| --- | ---: | --- |
-| **#18** Vite / vite-plugin-dts | **22** | `vite` (9), `postcss` (4), `lodash` (3), `nanoid` (2), `esbuild`, `rollup`, `vue-template-compiler`, `@babel/core` |
-| **#20** ESLint / typescript-eslint | **13** | `minimatch` (4), `js-yaml` (3), `picomatch` (3), `brace-expansion` (2), `flatted` |
-| **#19** Vitest / jsdom | **5** | `vitest` (2, **both critical**), `ws` (2), `form-data` |
+| Cleared by                         | Alerts | Packages                                                                                                           |
+| ---------------------------------- | -----: | ------------------------------------------------------------------------------------------------------------------ |
+| **#18** Vite / vite-plugin-dts     | **22** | `vite` (9), `postcss` (4), `lodash` (3), `nanoid` (2), `esbuild`, `rollup`, `vue-template-compiler`, `@babel/core` |
+| **#20** ESLint / typescript-eslint | **13** | `minimatch` (4), `js-yaml` (3), `picomatch` (3), `brace-expansion` (2), `flatted`                                  |
+| **#19** Vitest / jsdom             |  **5** | `vitest` (2, **both critical**), `ws` (2), `form-data`                                                             |
 
 Two chains are worth naming:
 
@@ -83,11 +83,11 @@ It is worth more than it looks. `postcss` carries four of the 40 advisories, and
 
 ### Test suite
 
-| | Count |
-| --- | ---: |
-| Unit tests | **65**, 4 files, green under `TZ=UTC` and `TZ=America/Chicago` |
-| Playwright e2e | 20, 1 spec file |
-| Coverage | **Never measured** |
+|                |                                                          Count |
+| -------------- | -------------------------------------------------------------: |
+| Unit tests     | **65**, 4 files, green under `TZ=UTC` and `TZ=America/Chicago` |
+| Playwright e2e |                                                20, 1 spec file |
+| Coverage       |                                             **Never measured** |
 
 Issues #19 and #23 both record 55 unit tests. The real number is 65 — the `1.0.3` timezone work added ten. Recorded here so the plan does not carry a stale figure forward.
 
@@ -100,10 +100,10 @@ MISSING DEPENDENCY  Cannot find dependency '@vitest/coverage-v8'
 
 Coverage is concentrated in the pure utilities. The two most complex files in the codebase have **zero** unit tests between them:
 
-| File | LOC | Unit tests |
-| --- | ---: | ---: |
-| `src/components/TimelineProvider.tsx` | 429 | 0 |
-| `src/hooks/usePan.ts` | 234 | 0 |
+| File                                  | LOC | Unit tests |
+| ------------------------------------- | --: | ---------: |
+| `src/components/TimelineProvider.tsx` | 429 |          0 |
+| `src/hooks/usePan.ts`                 | 234 |          0 |
 
 `Timeline.test.tsx` holds shallow render assertions only. No interaction is covered at the unit level; the 20 e2e tests carry the entire behavioral load.
 
@@ -111,13 +111,13 @@ Coverage is concentrated in the pure utilities. The two most complex files in th
 
 **React 19.** `peerDependencies` advertises `react: "^18.0.0 || ^19.0.0"` and the README markets "Built with React 18/19". Every dev dependency, the demo, and the whole suite run on React 18. React 19 support is asserted and never exercised.
 
-**Accessibility.** The repository description asserts "WCAG 2.1 AA accessible" while the CHANGELOG lists "Full WCAG 2.1 AA compliance" under *Planned* — the same conformance claimed as shipped and pending at once. Measured against the implementation:
+**Accessibility.** The repository description asserts "WCAG 2.1 AA accessible" while the CHANGELOG lists "Full WCAG 2.1 AA compliance" under _Planned_ — the same conformance claimed as shipped and pending at once. Measured against the implementation:
 
-| | Count |
-| --- | ---: |
-| `aria-*` / `role=` usages | 14 |
-| Components carrying any | **3** — `EventMarker`, `EventPopup`, `Timeline` |
-| Components with none | **6** — `Band`, `EventTrack`, `HotZones`, `OverviewMarkers`, `TimeScale`, `TimelineProvider` |
+|                           |                                                                                        Count |
+| ------------------------- | -------------------------------------------------------------------------------------------: |
+| `aria-*` / `role=` usages |                                                                                           14 |
+| Components carrying any   |                                              **3** — `EventMarker`, `EventPopup`, `Timeline` |
+| Components with none      | **6** — `Band`, `EventTrack`, `HotZones`, `OverviewMarkers`, `TimeScale`, `TimelineProvider` |
 
 Issue #24 records these 14 usages as spread "across 10 components". They are not; they sit in three. Two thirds of the component surface has no ARIA at all, which makes the conformance claim weaker than the issue implies, not stronger.
 
@@ -151,9 +151,18 @@ pnpm workspaces, Node `>=18`, CI matrix on Node 18/20/22/24 at `TZ=UTC` plus Nod
 
 **Approach:** Vitest and jsdom move together — Vitest declares jsdom as a peer, so they cannot be staged apart. This is the smallest of the three upgrades and the most isolated: nothing in the build or lint path depends on it.
 
+> **Correction (post-execution).** The independence claim held only up to **vitest 3**. `vitest@4` requires `vite ^6 || ^7 || ^8`, so it is gated on §2 (#18) — this issue is **not** independent of the build upgrade at its stated target. #19 shipped `vitest@3.2.7` + `jsdom@26.1.0` (both criticals, `ws` and `form-data` cleared); the step to `vitest@4` / `jsdom@30` was split out to #50.
+
 ### 1.1 Vitest 1 → 4, jsdom 24 → 30
 
 **Deliverable:** `vitest@4`, `jsdom@30`, `vitest.config.ts` migrated, all 65 tests green under both `TZ=UTC` and `TZ=America/Chicago`, and the `vitest`, `ws` and `form-data` advisories gone.
+
+> **Correction (post-execution).** `vitest@4` and `jsdom@30` are **not installable at this point in the sequence**, and neither constraint was checked when the plan was written:
+>
+> - `vitest@4` needs Vite 6+ → gated on #18.
+> - `jsdom@30` needs Node `^22.22.2 || ^24.15.0 || >=26` → breaks the Node 18 and 20 CI legs and contradicts `engines.node: >=18`.
+>
+> #19 shipped `vitest@3.2.7` + `jsdom@26.1.0` — 26 is the last jsdom that keeps the promised Node range **and** drops `form-data`. The advisory goal was met in full. The remaining bump is #50, gated on #18 and on the Node-floor decision (now settled below).
 
 Vitest 3 and 4 both changed config surface and default reporters; `environment: 'jsdom'`, `globals: true` and `setupFiles` all need re-checking against v4 rather than assumed to carry over.
 
@@ -178,19 +187,21 @@ Vitest 3 and 4 both changed config surface and default reporters; `environment: 
 
 `vite-plugin-dts@5` drops the API Extractor rollup path that emits this, and with it the `lodash` and Vue-toolchain dependency chains.
 
+> **Correction (post-execution).** v5 does **not** drop the API Extractor path — it drops the _bundled copy_ of `@microsoft/api-extractor` and still uses it for the type rollup, so it had to be added as a **direct** devDependency (7.58.12). That version no longer depends on `lodash`, so the advisory outcome is as predicted, by a different mechanism. Three regressions the plan did not foresee also surfaced here — see the execution record below.
+
 ### 2.2 The published artifact must not regress
 
 **Deliverable:** a before/after comparison of the packed tarball, not just a successful build.
 
 `1.0.3` ships 11 files at 107,595 bytes packed. The declaration bundler is changing underneath the type emit, so the risk is specifically that `dist/index.d.cts` or `dist/index.d.ts` comes out different in shape while the build still reports success.
 
-| Must hold after the upgrade | Baseline |
-| --- | --- |
-| File count | 11, including `LICENSE` and `style.css` |
-| `dist/index.d.cts` present | 19,916 bytes |
-| `attw` across four resolution modes | Clean |
-| Public export surface | Identical — diff the `.d.ts` |
-| Bundle size | 11,737 B gzipped ESM; any change explained |
+| Must hold after the upgrade         | Baseline                                   |
+| ----------------------------------- | ------------------------------------------ |
+| File count                          | 11, including `LICENSE` and `style.css`    |
+| `dist/index.d.cts` present          | 19,916 bytes                               |
+| `attw` across four resolution modes | Clean                                      |
+| Public export surface               | Identical — diff the `.d.ts`               |
+| Bundle size                         | 11,737 B gzipped ESM; any change explained |
 
 **Special case:** the root `LICENSE` reaches the tarball only because `pnpm pack` pulls it in from the workspace root. It is not in the package directory. Any change to how packing happens must be checked against the file list, not assumed.
 
@@ -232,10 +243,10 @@ Vitest 3 and 4 both changed config surface and default reporters; `environment: 
 
 The package promises `^18.0.0 || ^19.0.0` and has never been run against React 19. Two honest options:
 
-| Option | Effect |
-| --- | --- |
-| **A. Prove it** | CI matrix leg running the suite against React 19 alongside 18. `@testing-library/react@16` is required for React 19. The promise becomes true and stays true |
-| **B. Narrow it** | Drop `^19` from `peerDependencies` until it is tested. Honest immediately, but a **breaking change** for any consumer already installing on React 19 |
+| Option           | Effect                                                                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **A. Prove it**  | CI matrix leg running the suite against React 19 alongside 18. `@testing-library/react@16` is required for React 19. The promise becomes true and stays true |
+| **B. Narrow it** | Drop `^19` from `peerDependencies` until it is tested. Honest immediately, but a **breaking change** for any consumer already installing on React 19         |
 
 **Recommendation: A.** B is semver-breaking in a minor release, and the promise has been public since `1.0.0` — narrowing it now would strand consumers who took the package at its word. The cost of A is one CI matrix dimension.
 
@@ -259,11 +270,11 @@ The package promises `^18.0.0 || ^19.0.0` and has never been run against React 1
 
 **Deliverable:** unit coverage for `TimelineProvider` (429 LOC) and `usePan` (234 LOC), plus interaction tests for `EventMarker` and `EventPopup`.
 
-| Target | Cases |
-| --- | --- |
-| `TimelineProvider` | inline data, `dataUrl` fetch, `dataUrls` multi-source merge, fetch failure, `jumpToDate`, theme switching, band synchronization |
-| `usePan` | drag pan, bounds clamping, keyboard arrow navigation, `+`/`-` zoom, wheel zoom |
-| `EventMarker`, `EventPopup` | click, keyboard activation |
+| Target                      | Cases                                                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `TimelineProvider`          | inline data, `dataUrl` fetch, `dataUrls` multi-source merge, fetch failure, `jumpToDate`, theme switching, band synchronization |
+| `usePan`                    | drag pan, bounds clamping, keyboard arrow navigation, `+`/`-` zoom, wheel zoom                                                  |
+| `EventMarker`, `EventPopup` | click, keyboard activation                                                                                                      |
 
 Thresholds from §5.1 are raised to the new floor once these land.
 
@@ -290,10 +301,10 @@ The baseline in #24 needs correcting as part of this: the 14 ARIA usages sit in 
 Measured baseline, 1200px viewport at 100px/day:
 
 | Events | Rendered nodes | ms per layout pass |
-| ---: | ---: | ---: |
-| 1,000 | 1 | 0.54 |
-| 10,000 | 3 | 4.00 |
-| 50,000 | 11 | 18.03 |
+| -----: | -------------: | -----------------: |
+|  1,000 |              1 |               0.54 |
+| 10,000 |              3 |               4.00 |
+| 50,000 |             11 |              18.03 |
 
 Node count is flat — culling works. Time is linear, because `filterVisibleEvents` re-scans and re-`parseDate`s every event on every pass, and the `useMemo` keys on values that change on every pan. At 50k a single pass exceeds the 16.7 ms budget for 60 FPS before React does any work.
 
@@ -313,11 +324,11 @@ Directions: parse each event's bounds once at load and carry epoch numbers on th
 
 Three things must be established by running them rather than read from documentation:
 
-| Unknown | Why it matters |
-| --- | --- |
-| npm version on the runner | Trusted publishing needs npm ≥ 11.5.1; `release.yml` pins Node 20, which ships npm 10.8.2 |
+| Unknown                                     | Why it matters                                                                                                                                                    |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| npm version on the runner                   | Trusted publishing needs npm ≥ 11.5.1; `release.yml` pins Node 20, which ships npm 10.8.2                                                                         |
 | Whether pnpm's `--filter` path carries OIDC | pnpm 9.0.0's recursive publish rebuilds the npm invocation and forwards only `--access`, `--dry-run`, `--otp`. That path already silently swallows `--provenance` |
-| Registry-side registration | The trusted publisher must be registered against the package on npmjs.com before the first OIDC publish |
+| Registry-side registration                  | The trusted publisher must be registered against the package on npmjs.com before the first OIDC publish                                                           |
 
 **Special case:** the `--provenance` finding from #17 is the precedent. A flag was accepted, silently dropped, and would have produced an unattested release that looked successful. Anything in this area is verified by inspecting the published result, never by a green workflow.
 
@@ -346,25 +357,25 @@ The bump is patch-level within `postcss@8`, dev-only, and has been green on all 
 
 ## Resolution model
 
-| Work item | Mode |
-| --- | --- |
-| §1 Vitest / jsdom (#19) | Autonomous — PR, then verify |
-| §2 Vite / dts / plugin-react (#18) | Autonomous — PR, then verify |
-| §3 ESLint flat config (#20) | Autonomous — PR, then verify |
-| §4.1 TypeScript and type packages (#21) | Autonomous — PR, then verify |
-| §4.2 React 19 — prove or narrow | **Review artifact** — the maintainer decides; A recommended |
-| §5.1 Coverage tooling (#22) | Autonomous — PR; **baseline number reported, thresholds set from it** |
-| §5.2 Unit tests (#23) | Autonomous — PR, then verify |
-| §6.1 README and CHANGELOG wording (#24) | Autonomous — PR |
-| §6.1 Repository description (#24) | **Owner-applied** — GitHub setting, no PR form |
-| §6.2 Layout performance (#36) | Autonomous — PR, benchmark before and after |
-| §6.3 README duplication (#37) | **Review artifact** — four options, no obvious winner; then applied |
-| §6.4 Workflow and npm changes (#42) | Autonomous — PR |
-| §6.4 Trusted-publisher registration (#42) | **Owner-applied** — npm registry setting |
-| §6.4 First OIDC publish, secret deletion | **Owner-applied — irreversible** |
-| §6.5 Workflow token scope (#44) | Autonomous — PR, then confirm the alerts close |
-| §6.6 Merge the open Dependabot PR (#33) | Autonomous — merge, then confirm the advisory count drops |
-| Untracked majors: `@vitejs/plugin-react`, `tailwindcss` | Recommend + apply — folded into §2 and a demo PR |
+| Work item                                               | Mode                                                                  |
+| ------------------------------------------------------- | --------------------------------------------------------------------- |
+| §1 Vitest / jsdom (#19)                                 | Autonomous — PR, then verify                                          |
+| §2 Vite / dts / plugin-react (#18)                      | Autonomous — PR, then verify                                          |
+| §3 ESLint flat config (#20)                             | Autonomous — PR, then verify                                          |
+| §4.1 TypeScript and type packages (#21)                 | Autonomous — PR, then verify                                          |
+| §4.2 React 19 — prove or narrow                         | **Review artifact** — the maintainer decides; A recommended           |
+| §5.1 Coverage tooling (#22)                             | Autonomous — PR; **baseline number reported, thresholds set from it** |
+| §5.2 Unit tests (#23)                                   | Autonomous — PR, then verify                                          |
+| §6.1 README and CHANGELOG wording (#24)                 | Autonomous — PR                                                       |
+| §6.1 Repository description (#24)                       | **Owner-applied** — GitHub setting, no PR form                        |
+| §6.2 Layout performance (#36)                           | Autonomous — PR, benchmark before and after                           |
+| §6.3 README duplication (#37)                           | **Review artifact** — four options, no obvious winner; then applied   |
+| §6.4 Workflow and npm changes (#42)                     | Autonomous — PR                                                       |
+| §6.4 Trusted-publisher registration (#42)               | **Owner-applied** — npm registry setting                              |
+| §6.4 First OIDC publish, secret deletion                | **Owner-applied — irreversible**                                      |
+| §6.5 Workflow token scope (#44)                         | Autonomous — PR, then confirm the alerts close                        |
+| §6.6 Merge the open Dependabot PR (#33)                 | Autonomous — merge, then confirm the advisory count drops             |
+| Untracked majors: `@vitejs/plugin-react`, `tailwindcss` | Recommend + apply — folded into §2 and a demo PR                      |
 
 **Deliverable (review artifact):** a single comment covering the §4.2 React 19 decision and the §6.3 deduplication options, each with a recommendation, for one round of approval rather than two.
 
@@ -377,7 +388,7 @@ The advisory-clearing upgrades come first, but **not** in severity order. #19 is
 1. **§6.6 Merge the open Dependabot PR (#33)** — first because it is already green and clears four advisories on its own. Merging it before the lockfile starts moving under three migrations means the `postcss` alerts are verifiably gone rather than lost in the churn.
 2. **§6.5 Workflow token scope (#44)** — four lines, no dependencies, and it closes both CodeQL alerts. Doing it now means the remaining security work is a single scanner's list instead of two.
 3. **§6.1 Accessibility claim (#24)** — early, despite being late in the plan's numbering. It is documentation and a repository setting, it depends on nothing, and it is the only item whose consequences reach outside the repository. It should not wait behind three dependency majors.
-4. **§1 Vitest / jsdom (#19)** — the only **critical** advisory, and the upgrade with the smallest blast radius. Also establishes that the suite still passes on a new runner *before* anything else changes underneath it. A test-runner migration performed after the build changes cannot distinguish its own breakage from the build's.
+4. **§1 Vitest / jsdom (#19)** — the only **critical** advisory, and the upgrade with the smallest blast radius. Also establishes that the suite still passes on a new runner _before_ anything else changes underneath it. A test-runner migration performed after the build changes cannot distinguish its own breakage from the build's.
 5. **§5.1 Coverage tooling (#22)** — immediately after #19, because the coverage provider must match the Vitest major, and because every later section wants a coverage number to move.
 6. **§2 Vite / dts / plugin-react (#18)** — clears 22 alerts and removes the Vue toolchain. Sequenced after the test suite is on a current runner so a build regression surfaces as a test failure rather than a mystery.
 7. **§3 ESLint flat config (#20)** — clears 13 alerts. Independent of the build, but sequenced after it so a flat-config migration is not debugged simultaneously with a Vite major.
@@ -427,6 +438,50 @@ Exercise the published artifact and the running application, not the working tre
 
 ---
 
+## Execution record (updated as the milestone runs)
+
+The plan is the pre-work artifact; this section reconciles it against what actually shipped. Added because the milestone is being executed in sequence and several plan assumptions did not survive contact.
+
+### Landed
+
+| #   | Section | Shipped as | Notes                                                                                                                               |
+| --- | ------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| #44 | §6.5    | `43df8b5`  | ci.yml token scope; both CodeQL alerts fixed; verified by forcing a failing e2e run and confirming the artifact still uploaded      |
+| #33 | §6.6    | `9333349`  | postcss 8.5.6 → 8.5.23; cleared 6 advisories (postcss + nanoid), not the 4 predicted                                                |
+| #24 | §6.1    | `0ce6dea`  | WCAG claim corrected in description, both READMEs, CHANGELOG. Baseline in #24 was wrong: 14 ARIA usages in **3** components, not 10 |
+| #19 | §1      | `edae45b`  | vitest 3.2.7 + jsdom 26 (not 4/30 — see §1 corrections); both criticals + ws + form-data cleared                                    |
+| #18 | §2      | `0211eaa`  | vite 8, plugin-react 6, vite-plugin-dts 5, vitest 4. Node floor narrowed to 20.19; ruleset required checks 8 → 7                    |
+
+### Three regressions §2 did not foresee (all caught by the §2.2 tarball/declaration diff)
+
+1. **`rollupTypes` renamed `bundleTypes`** in vite-plugin-dts 5 — the old name is silently ignored, producing a 1.1 kB re-export stub instead of the 19.9 kB rolled-up declarations while the build reports success.
+2. **CSS entrypoint renamed** — Vite 6 changed the default lib CSS asset name to the package name, emitting `dist/react-simile-timeline.css` and 404ing the documented `react-simile-timeline/style.css` import. Fixed with `cssFileName: 'style'`. This was also the true cause of the failed Dependabot PR (#46), first misattributed to `@vitejs/plugin-react`.
+3. **vitest 3 kept a second Vite 5 in the tree** — its peer range is `^5 || ^6 || ^7`, so all 9 vite advisories would have stayed open while the upgrade looked complete. vitest 4 resolved it.
+
+The §2.2 discipline is what surfaced all three. The plan's _method_ held even where its _claims_ did not.
+
+### The Node floor — the miss that mattered
+
+§0 recorded `Node >=18` but never checked Vite's `engines`. Vite 8 requires `^20.19.0 || >=22.12.0`, so the Node 18 CI leg failed (`SyntaxError: … 'node:util' does not provide an export named 'styleText'`). **Option A** was chosen: `engines.node` narrowed to `>=20.19.0`, CI matrix now 20/22/24, and the `main` ruleset's required checks reduced from 8 to 7 (the plan did not anticipate the ruleset edit; removing a required check without it deadlocks every future merge). This is the change that reopens the semver question in Constraints.
+
+### Two cascades the plan did not model
+
+- **Dependabot Updates workflow** was failing on a chain of security updates it could not resolve, each unblocked in turn: `form-data` (jsdom@24, #19) → `@babel/core` (@vitejs/plugin-react@4, #18) → `flatted` (eslint@8, **#20, still open**). #20 is the last known blocker of this kind.
+- **Advisory count**: 42 → 34 (§6.5/§6.6) → 29 (#19) → **14** (#18). The remaining 14: 11 trace to eslint@8 / typescript-eslint@7 (**#20**), 3 are dev-only leftovers filed as **#52**.
+
+### Issues spawned by execution (not in the original plan)
+
+| #   | Why it exists                                                                                         |
+| --- | ----------------------------------------------------------------------------------------------------- |
+| #50 | vitest 4 / jsdom 30 — split from #19; gated on #18 (done) and the Node floor (done), so now unblocked |
+| #52 | esbuild, vue-template-compiler, rollup — dev-only advisories the Vite upgrade could not dislodge      |
+
+### Order actually executed vs planned
+
+The plan led with §6.6 and §6.5 (cheap security wins) ahead of §6.1, which matched. §1 (#19) then §2 (#18) held. **Not yet started:** §3 (#20), §4 (#21), §5 (#22, #23), §6.2 (#36), §6.3 (#37), §6.4 (#42). #20 is the recommended next step — biggest advisory cluster and the last Dependabot blocker.
+
+---
+
 ## Constraints (hard rules in force)
 
 - **PRs only — no direct commits** (global rule), mechanically enforced by the ruleset on `main`.
@@ -434,7 +489,10 @@ Exercise the published artifact and the running application, not the working tre
 - **Publishing is owner-applied.** The tag push, the npm trusted-publisher registration, and the `NPM_TOKEN` deletion are not performed on the maintainer's behalf. `1.0.0` is permanently uninstallable on this package because a publish was reversed.
 - **Do not delete or move any tag.** They are the only surviving reference to the pre-rebuild history (#8). There are 9.
 - **The public API surface does not change.** This is a toolchain milestone. Any change to the `exports` map, the emitted declarations, or the exported symbol set is a defect in the upgrade, not a feature of it — the `.d.ts` is diffed, not eyeballed.
-- **Semver:** `1.1.0` as a minor. The dependency majors are all `devDependencies` and invisible to consumers. The one consumer-visible decision is the §4.2 peer range — option A is additive; option B would be breaking and is therefore not a `1.1.0` change.
+- **Semver:** `1.1.0` as a minor. ~~The dependency majors are all `devDependencies` and invisible to consumers. The one consumer-visible decision is the §4.2 peer range~~ **— superseded, see the OPEN DECISION below.** #18 raised `engines.node` from `>=18.0.0` to `>=20.19.0`, which a Node 18 consumer sees at install time. There are now **two** consumer-visible changes, not one, and whether the `engines` bump keeps this a minor is unresolved.
+
+> **OPEN DECISION — is `1.1.0` still the right version?** The plan asserted this milestone was a clean minor on the premise that everything shipping was a `devDependency`. That premise is dead: `engines.node` narrowed to `>=20.19.0` (Vite 8's floor). The library's built output still runs on Node 18 — only the toolchain needs 20.19 — so this is arguably a minor. But a strict reading of semver treats a narrowed `engines` range as a breaking change for a Node 18 installer, which would make it **`2.0.0`**. This must be decided before the §4.2 version bump. Defaulting silently to `1.1.0` is exactly the kind of unreviewed call §1 of the `v1.0.3` plan existed to prevent.
+
 - **Peer-dependency promise:** `react: ^18 || ^19` is either tested or narrowed by the end of this milestone. It does not survive in its current unproven state.
 - **Scope discipline.** #25, the WCAG audit and remediation, is a release of its own and does not enter this milestone however tempting it is to finish the accessibility story in one pass. Feature milestones `v1.2.0`–`v1.4.0` stay closed.
 - **No client or personal names anywhere** (global rule) — role language only.


### PR DESCRIPTION
Half the `v1.1.0` milestone is merged (#44, #33, #24, #19, #18) and half is not, so the plan is still a live document — and it now misdescribes what shipped. This corrects the wrong claims in place and adds an execution record.

## Inline corrections

| Plan claim | Correction |
| --- | --- |
| §1 "the most isolated: nothing in the build or lint path depends on it" | False at the stated target. `vitest@4` needs Vite 6+, so #19 is **gated on #18**. Held only up to vitest 3 |
| §1.1 deliverable "`vitest@4`, `jsdom@30`" | Neither installable at that point in the sequence; neither engine constraint was checked when the plan was written |
| §2.1 "drops the API Extractor rollup path" | v5 drops the *bundled copy*, not the path — api-extractor is now a direct devDependency |
| **Semver constraint** | **Premise dead.** See below |

## The semver decision — surfaced, not decided

The plan asserted `1.1.0` is a clean minor because "the dependency majors are all `devDependencies` and invisible to consumers." **#18 killed that premise** by narrowing `engines.node` from `>=18.0.0` to `>=20.19.0`, which a Node 18 consumer sees at install time.

> **OPEN DECISION.** The library's built output still runs on Node 18 — only the toolchain needs 20.19 — so this is arguably a minor. But a strict reading of semver treats a narrowed `engines` range as breaking for a Node 18 installer, which would make it **`2.0.0`**. This must be decided before the §4.2 version bump. Defaulting silently to `1.1.0` is exactly the unreviewed call §1 of the `v1.0.3` plan existed to prevent.

I have **not** made this call — it is yours. The plan now carries it as an explicit open item rather than a buried assumption.

## New execution record

A reconciliation section covering: the five merges, the three silent regressions the §2.2 diff caught, the Node-floor miss and the ruleset edit it forced (required checks 8 → 7), the two Dependabot cascades, the advisory trajectory 42 → 14, and the two issues execution spawned (#50, #52).

## Method vs claims

The plan's *method* held — the §2.2 tarball/declaration diff is what surfaced all three regressions. Its *specific claims* were wrong in four places and it missed the Node floor entirely. The record now says so plainly.

Documentation only.