### PR TITLE
docs: make the root README the single source of truth, guard drift in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,32 @@ jobs:
           path: packages/react-simile-timeline/coverage/
           retention-days: 7
 
+  # The root README.md is the source of truth; the package copy that ships to
+  # npm is generated from it by `pnpm sync:readme`. This fails the build if the
+  # two drift, so a README edit that touches only one file cannot merge - the
+  # trap that put a dead demo link (#15) and a stale badge (#16) in front of npm
+  # consumers while GitHub looked fine.
+  readme-sync:
+    name: readme-sync
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check README is in sync
+        run: pnpm sync:readme:check
+
   e2e:
     name: e2e
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,22 @@ pnpm build:lib
 - Add JSDoc comments for public APIs
 - Avoid `any` types without justification
 
+## Editing the README
+
+The repository root `README.md` is the **single source of truth**. The package
+copy at `packages/react-simile-timeline/README.md` is generated from it — it is
+what ships in the npm tarball and renders on npmjs.com, so it cannot be a
+symlink (`pnpm pack` drops symlinked files).
+
+After editing the root README, regenerate the package copy and commit both:
+
+```bash
+pnpm sync:readme
+```
+
+CI runs `pnpm sync:readme:check` and fails the build if the two files drift, so
+edit the root file, never the package copy directly.
+
 ## Commit Messages
 
 We use conventional commits. Format:

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -77,6 +77,14 @@ export default tseslint.config(
     },
   },
 
+  // Node CLI scripts print to stdout by design.
+  {
+    files: ['scripts/**/*.js', 'scripts/**/*.mjs'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+
   // Must be last: turns off every stylistic rule Prettier owns.
   prettier
 );

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write \"**/*.{ts,tsx,json,md}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,json,md}\"",
+    "sync:readme": "node scripts/sync-readme.mjs",
+    "sync:readme:check": "node scripts/sync-readme.mjs --check",
     "typecheck": "pnpm -r typecheck",
     "clean": "pnpm -r clean && rm -rf node_modules"
   },

--- a/scripts/sync-readme.mjs
+++ b/scripts/sync-readme.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Single source of truth for the README.
+ *
+ * The repo root README.md is authoritative: it is what GitHub renders. The
+ * published package needs its own copy inside packages/react-simile-timeline,
+ * because that copy is what ships in the npm tarball and renders on npmjs.com
+ * (a symlink does not work — pnpm pack drops symlinked files, which is how the
+ * missing-README bug that 1.0.2 fixed would return).
+ *
+ * This script copies the root README into the package. Run it after editing
+ * the root README:
+ *
+ *   pnpm sync:readme
+ *
+ * With --check it copies nothing and instead exits non-zero when the two files
+ * differ, so CI fails on drift rather than shipping a stale package README.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, '..');
+const source = join(root, 'README.md');
+const target = join(root, 'packages', 'react-simile-timeline', 'README.md');
+
+const check = process.argv.includes('--check');
+const sourceText = readFileSync(source, 'utf8');
+
+let targetText = '';
+try {
+  targetText = readFileSync(target, 'utf8');
+} catch {
+  // Missing target is a drift the check should catch and the sync should fix.
+}
+
+if (check) {
+  if (sourceText !== targetText) {
+    console.error(
+      'README drift: packages/react-simile-timeline/README.md is out of sync ' +
+        'with the root README.md.\nRun `pnpm sync:readme` and commit the result.'
+    );
+    process.exit(1);
+  }
+  console.log('README in sync.');
+} else {
+  if (sourceText === targetText) {
+    console.log('README already in sync.');
+  } else {
+    writeFileSync(target, sourceText);
+    console.log('Synced root README.md -> packages/react-simile-timeline/README.md');
+  }
+}


### PR DESCRIPTION
Closes #37. Executes §6.3 of the [v1.1.0 plan](https://github.com/thbst16/react-simile-timeline/blob/main/plans/2026-08-18-toolchain-modernization-plan.md).

## The problem

`README.md` (root) and `packages/react-simile-timeline/README.md` were **byte-identical with nothing keeping them so**. The package copy ships in the npm tarball and renders on npmjs.com; the root renders on GitHub. This split already cost twice — the dead demo link (#15) and stale badge (#16) each had to be fixed in both files, and a root-only fix would have left the defect in front of npm consumers.

## The decision (review artifact)

Four options were on the table. **Symlink was tried first and rejected empirically:**

```
$ ln -s ../../README.md packages/react-simile-timeline/README.md
$ pnpm pack ...
$ tar -tzf *.tgz | grep -i readme
(nothing)
```

`pnpm pack` **drops symlinked files** — the package would ship with no README, the exact regression `1.0.2` existed to fix. So a symlink is out.

**Chosen: root README is the single source of truth, package copy generated from it, drift guarded in CI.**

- `scripts/sync-readme.mjs` copies root → package (`pnpm sync:readme`); `--check` exits non-zero on drift.
- A `readme-sync` CI job runs `pnpm sync:readme:check`, so a README edit touching only one file **cannot merge**.
- Both files stay committed, so the tarball always carries a real README (verified: **7,985 bytes** in the packed tarball) and GitHub always renders the root.

## Verified both directions

- Introduced drift → `--check` exits 1 with a fix hint.
- `pnpm sync:readme` repairs it → `--check` passes.

`CONTRIBUTING.md` documents the workflow: edit the root, run `pnpm sync:readme`, never edit the package copy directly.

## One thing this surfaced

Adding a `scripts/**/*.{js,mjs}` glob to the ESLint config crashed ESLint — `minimatch@3.1.5` (from `eslint-plugin-react`) can't brace-expand against the `brace-expansion@5` the #20 overrides resolve. Worked around here with de-braced globs; filed as **#61** with the proper fix.

## Verification

`pnpm lint`, `pnpm typecheck` clean; **120 tests** pass; tarball README intact.