### PR TITLE
fix: scope the brace-expansion override per major, restore brace globs

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -79,7 +79,7 @@ export default tseslint.config(
 
   // Node CLI scripts print to stdout by design.
   {
-    files: ['scripts/**/*.js', 'scripts/**/*.mjs'],
+    files: ['scripts/**/*.{js,mjs}'],
     rules: {
       'no-console': 'off',
     },

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
       "minimatch@>=9 <9.0.7": ">=9.0.7",
       "picomatch@<2.3.2": ">=2.3.2",
       "picomatch@>=4 <4.0.4": ">=4.0.4",
-      "brace-expansion@<1.1.16": ">=1.1.16",
-      "brace-expansion@>=2 <2.1.2": ">=2.1.2",
-      "js-yaml@>=4 <4.3.1": ">=4.3.1"
+      "js-yaml@>=4 <4.3.1": ">=4.3.1",
+      "brace-expansion@1": "^1.1.16",
+      "brace-expansion@2": "^2.1.2"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,9 @@ overrides:
   minimatch@>=9 <9.0.7: '>=9.0.7'
   picomatch@<2.3.2: '>=2.3.2'
   picomatch@>=4 <4.0.4: '>=4.0.4'
-  brace-expansion@<1.1.16: '>=1.1.16'
-  brace-expansion@>=2 <2.1.2: '>=2.1.2'
   js-yaml@>=4 <4.3.1: '>=4.3.1'
+  brace-expansion@1: ^1.1.16
+  brace-expansion@2: ^2.1.2
 
 importers:
 
@@ -963,6 +963,9 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -974,6 +977,9 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -1060,6 +1066,9 @@ packages:
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3474,11 +3483,18 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.9.8: {}
 
   binary-extensions@2.3.0: {}
+
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
 
   brace-expansion@5.0.9:
     dependencies:
@@ -3574,6 +3590,8 @@ snapshots:
   commander@10.0.1: {}
 
   commander@4.1.1: {}
+
+  concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4489,7 +4507,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.9
+      brace-expansion: 1.1.18
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
Closes #61. Executes §3 of the [v1.1.1 plan](https://github.com/thbst16/react-simile-timeline/blob/main/plans/2026-08-19-security-release-hardening-plan.md).

## The bug

The `brace-expansion` overrides from #20 were open-ended:

```json
"brace-expansion@<1.1.16": ">=1.1.16",
"brace-expansion@>=2 <2.1.2": ">=2.1.2"
```

pnpm satisfied `>=1.1.16` with the **latest** (5.0.9) and collapsed `brace-expansion` to a single 5.x tree-wide — including `minimatch@3.1.5` (from `eslint-plugin-react`), which needs the **1.x** API where the default export is a function. Any ESLint config with a brace `{a,b}` glob then crashed:

```
TypeError: expand is not a function
    at Minimatch.braceExpand (minimatch@3.1.5)
```

#37 worked around it with de-braced globs; the incompatibility stayed latent.

## The fix — per-major selectors

```json
"brace-expansion@1": "^1.1.16",
"brace-expansion@2": "^2.1.2"
```

Each consumer stays in its own major:

| Consumer | brace-expansion | |
| --- | --- | --- |
| `minimatch@3.1.5` | **1.1.18** | patched (advisory is `<1.1.16`), still 1.x — API intact |
| `minimatch@10.2.3` | 5.0.9 | not vulnerable |

## Verified

- **The #37 workaround is reverted** — the ESLint scripts override uses `'scripts/**/*.{js,mjs}'` again, and `pnpm lint` runs **clean** instead of crashing. That's the definitive #61 test.
- `pnpm audit` stays clear on `brace-expansion`.
- Lockfile change is minimal: `brace-expansion@1.1.18` + its 1.x deps (`balanced-match`, `concat-map`) for `minimatch@3.1.5`. No unrelated churn.
- `pnpm typecheck`, `pnpm build:lib` clean; **120 tests** pass.

Dev-tooling only; no runtime, API, or declaration change.