### PR TITLE
a11y(keyboard): scope pan/zoom to focused timeline, make popup a real modal (§1.2, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,25 @@ interface Theme {
 
 ### Keyboard Navigation
 
-| Key | Action |
-|-----|--------|
-| `←` / `→` | Pan left/right |
-| `+` / `=` | Zoom in |
-| `-` | Zoom out |
-| `Escape` | Close popup |
+The timeline is fully operable by keyboard. `Tab` moves through the interactive
+elements in reading order: the timeline band first (a single tab stop for
+pan/zoom), then each event marker. The pan and zoom shortcuts only act while the
+timeline band or one of its markers holds focus, so an embedded timeline never
+hijacks the page's arrow keys.
+
+| Key | Focus | Action |
+|-----|-------|--------|
+| `Tab` / `Shift`+`Tab` | anywhere | Move to the next / previous element (timeline band, then markers) |
+| `←` / `→` | timeline focused | Pan left / right |
+| `+` / `=` | timeline focused | Zoom in |
+| `-` | timeline focused | Zoom out |
+| `Enter` / `Space` | marker focused | Open the event popup |
+| `Tab` | popup open | Cycle focus within the popup (focus is trapped) |
+| `Escape` | popup open | Close the popup and return focus to the marker |
+
+When a popup opens, focus moves into the dialog and is trapped there until it
+closes; closing it (via `Escape` or the close button) restores focus to the
+marker that opened it.
 
 ---
 

--- a/demo/tests/keyboard.spec.ts
+++ b/demo/tests/keyboard.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/test';
+
+// Keyboard operability (§1.2, WCAG 2.1.1 / 2.4.3). Exercises the real thing in a
+// browser: the timeline is reachable and driveable by keyboard alone, the
+// pan/zoom shortcuts are scoped to the focused timeline rather than global, and
+// the event popup is a proper modal — focus moves in, is trapped, and is
+// restored to the opening marker on close.
+
+const firstTimeline = (page: import('@playwright/test').Page) =>
+  page.locator('[data-testid="timeline-container"]').first();
+
+// Is the browser's active element inside the (portaled) popup dialog?
+const focusIsInPopup = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => {
+    const popup = document.querySelector('.timeline-popup');
+    return !!popup && popup.contains(document.activeElement);
+  });
+
+test.describe('keyboard operability', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('arrow keys pan only once the timeline band is focused', async ({ page }) => {
+    const timeline = firstTimeline(page);
+    const label = timeline.locator('.timeline-scale__label').first();
+    await label.waitFor();
+
+    const initial = await label.textContent();
+
+    // Nothing in the timeline is focused yet — arrows must not pan it.
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(150);
+    expect(await label.textContent()).toBe(initial);
+
+    // Focus the primary band directly (keyboard-only path, no pointer) and pan.
+    await timeline.locator('.timeline-band--detail').first().focus();
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press('ArrowRight');
+    }
+    await page.waitForTimeout(150);
+    expect(await label.textContent()).not.toBe(initial);
+  });
+
+  test('+/- zoom only once the timeline band is focused', async ({ page }) => {
+    const timeline = firstTimeline(page);
+    const labels = timeline.locator('.timeline-scale__label');
+    await labels.first().waitFor();
+
+    const initial = await labels.allTextContents();
+
+    // Not focused — zoom keys are ignored.
+    await page.keyboard.press('+');
+    await page.keyboard.press('+');
+    await page.waitForTimeout(150);
+    expect(await labels.allTextContents()).toEqual(initial);
+
+    // Focused — zoom changes the scale granularity.
+    await timeline.locator('.timeline-band--detail').first().focus();
+    await page.keyboard.press('+');
+    await page.keyboard.press('+');
+    await page.waitForTimeout(200);
+    expect(await labels.allTextContents()).not.toEqual(initial);
+  });
+
+  test('the timeline band is reachable as a tab stop', async ({ page }) => {
+    const band = firstTimeline(page).locator('.timeline-band--detail').first();
+    await band.waitFor();
+    // A single tab stop with the pan/zoom shortcuts advertised to AT.
+    await expect(band).toHaveAttribute('tabindex', '0');
+    await expect(band).toHaveAttribute('aria-keyshortcuts', 'ArrowLeft ArrowRight + -');
+  });
+
+  test('marker opens the popup with Enter, traps focus, restores it on Escape', async ({
+    page,
+  }) => {
+    const marker = page.locator('.timeline-event[role="button"]').first();
+    await marker.waitFor();
+    await marker.focus();
+    const markerLabel = await marker.getAttribute('aria-label');
+
+    // Enter on the focused marker opens the popup.
+    await page.keyboard.press('Enter');
+    const popup = page.locator('.timeline-popup');
+    await expect(popup).toBeVisible();
+
+    // Focus moved into the dialog.
+    expect(await focusIsInPopup(page)).toBe(true);
+
+    // Tab stays trapped inside the dialog.
+    for (let i = 0; i < 6; i++) {
+      await page.keyboard.press('Tab');
+      expect(await focusIsInPopup(page)).toBe(true);
+    }
+
+    // Escape closes it and returns focus to the marker that opened it.
+    await page.keyboard.press('Escape');
+    await expect(popup).toHaveCount(0);
+    const restored = await page.evaluate(
+      () => (document.activeElement as HTMLElement | null)?.getAttribute('aria-label') ?? null
+    );
+    expect(restored).toBe(markerLabel);
+  });
+});

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -221,12 +221,25 @@ interface Theme {
 
 ### Keyboard Navigation
 
-| Key | Action |
-|-----|--------|
-| `←` / `→` | Pan left/right |
-| `+` / `=` | Zoom in |
-| `-` | Zoom out |
-| `Escape` | Close popup |
+The timeline is fully operable by keyboard. `Tab` moves through the interactive
+elements in reading order: the timeline band first (a single tab stop for
+pan/zoom), then each event marker. The pan and zoom shortcuts only act while the
+timeline band or one of its markers holds focus, so an embedded timeline never
+hijacks the page's arrow keys.
+
+| Key | Focus | Action |
+|-----|-------|--------|
+| `Tab` / `Shift`+`Tab` | anywhere | Move to the next / previous element (timeline band, then markers) |
+| `←` / `→` | timeline focused | Pan left / right |
+| `+` / `=` | timeline focused | Zoom in |
+| `-` | timeline focused | Zoom out |
+| `Enter` / `Space` | marker focused | Open the event popup |
+| `Tab` | popup open | Cycle focus within the popup (focus is trapped) |
+| `Escape` | popup open | Close the popup and return focus to the marker |
+
+When a popup opens, focus moves into the dialog and is trapped there until it
+closes; closing it (via `Escape` or the close button) restores focus to the
+marker that opened it.
 
 ---
 

--- a/packages/react-simile-timeline/src/components/Band.tsx
+++ b/packages/react-simile-timeline/src/components/Band.tsx
@@ -64,6 +64,7 @@ export function Band({ config, isPrimary = false }: BandProps) {
     onPanStart: () => actions.setIsPanning(true),
     onPanEnd: () => actions.setIsPanning(false),
     enableKeyboard: isPrimary, // Only primary band handles keyboard
+    scopeRef: containerRef, // Scope arrow-key panning to the focused band
     keyboardPanAmount,
   });
 
@@ -113,6 +114,13 @@ export function Band({ config, isPrimary = false }: BandProps) {
         return;
       }
 
+      // Only zoom while focus is inside this band, so an embedded timeline does
+      // not hijack the page's +/- keys and the popup modal keeps its keys.
+      const container = containerRef.current;
+      if (!container || !container.contains(document.activeElement)) {
+        return;
+      }
+
       switch (e.key) {
         case '+':
         case '=':
@@ -150,6 +158,18 @@ export function Band({ config, isPrimary = false }: BandProps) {
       }}
       onPointerDown={panProps.onPointerDown}
       data-band-id={config.id}
+      // The primary band is the keyboard entry point: it takes a tab stop and
+      // exposes its pan/zoom shortcuts. Secondary bands stay non-focusable and
+      // are driven through the primary band's synchronized state.
+      {...(isPrimary
+        ? {
+            tabIndex: 0,
+            role: 'group',
+            'aria-label':
+              'Timeline. Use the left and right arrow keys to pan, and the plus and minus keys to zoom.',
+            'aria-keyshortcuts': 'ArrowLeft ArrowRight + -',
+          }
+        : {})}
     >
       {/* Hot zones layer - renders behind events */}
       {hotZones.length > 0 && (

--- a/packages/react-simile-timeline/src/components/EventMarker.tsx
+++ b/packages/react-simile-timeline/src/components/EventMarker.tsx
@@ -46,12 +46,26 @@ export function EventMarker({
 
   const isSelected = state.selectedEvent === event;
 
+  const openPopup = useCallback((position: { x: number; y: number }) => {
+    actions.setSelectedEvent(isSelected ? null : event, position);
+  }, [actions, event, isSelected]);
+
   const handleClick = useCallback((e: React.MouseEvent) => {
     e.stopPropagation();
     // Capture click position for popup positioning
-    const clickPosition = { x: e.clientX, y: e.clientY };
-    actions.setSelectedEvent(isSelected ? null : event, clickPosition);
-  }, [actions, event, isSelected]);
+    openPopup({ x: e.clientX, y: e.clientY });
+  }, [openPopup]);
+
+  // Keyboard activation (Enter/Space). A key press carries no pointer
+  // coordinates, so anchor the popup to the marker's on-screen box instead of
+  // the (undefined -> NaN) pointer position a synthetic mouse event would give.
+  const handleKeyActivate = useCallback((e: React.KeyboardEvent) => {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    e.stopPropagation();
+    const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    openPopup({ x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 });
+  }, [openPopup]);
 
   const color = event.color || (isDuration ? DEFAULT_TAPE_COLOR : DEFAULT_COLOR);
   const textColor = event.textColor || 'var(--event-text-color, #333)';
@@ -87,7 +101,7 @@ export function EventMarker({
         tabIndex={0}
         aria-label={ariaLabel}
         aria-pressed={isSelected}
-        onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleClick(e as unknown as React.MouseEvent); } }}
+        onKeyDown={handleKeyActivate}
       >
         {/* Duration tape */}
         <div

--- a/packages/react-simile-timeline/src/components/EventPopup.test.tsx
+++ b/packages/react-simile-timeline/src/components/EventPopup.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { EventPopup } from './EventPopup';
@@ -101,5 +101,98 @@ describe('EventPopup — dismissal', () => {
       fireEvent.keyDown(document, { key: 'a' });
     });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});
+
+describe('EventPopup — focus management', () => {
+  // Render the popup with a focusable opener, focus it, then open the popup.
+  // Focus-in happens on a setTimeout(0), so callers advance fake timers.
+  function openFromFocusedTrigger(evt: TimelineEvent = event): HTMLElement {
+    function Opener() {
+      const { actions } = useTimelineContext();
+      return (
+        <button onClick={() => actions.setSelectedEvent(evt, { x: 50, y: 50 })}>
+          open
+        </button>
+      );
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TimelineProvider events={[evt]}>{children}</TimelineProvider>
+    );
+    render(
+      <>
+        <Opener />
+        <EventPopup />
+      </>,
+      { wrapper }
+    );
+    const opener = screen.getByText('open');
+    opener.focus();
+    fireEvent.click(opener);
+    return opener;
+  }
+
+  it('moves focus into the dialog when it opens', () => {
+    vi.useFakeTimers();
+    try {
+      openFromFocusedTrigger();
+      act(() => {
+        vi.runAllTimers();
+      });
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('restores focus to the opener when it closes', () => {
+    vi.useFakeTimers();
+    try {
+      const opener = openFromFocusedTrigger();
+      act(() => {
+        vi.runAllTimers();
+      });
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Escape' });
+      });
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(opener);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('wraps Tab and Shift+Tab within the dialog', () => {
+    vi.useFakeTimers();
+    try {
+      openFromFocusedTrigger();
+      act(() => {
+        vi.runAllTimers();
+      });
+      const dialog = screen.getByRole('dialog');
+      const focusable = dialog.querySelectorAll<HTMLElement>(
+        'a[href], button:not([disabled])'
+      );
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      expect(focusable.length).toBeGreaterThan(1);
+
+      // Tab from the last element wraps to the first.
+      last.focus();
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Tab' });
+      });
+      expect(document.activeElement).toBe(first);
+
+      // Shift+Tab from the first element wraps to the last.
+      first.focus();
+      act(() => {
+        fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+      });
+      expect(document.activeElement).toBe(last);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/react-simile-timeline/src/components/EventPopup.tsx
+++ b/packages/react-simile-timeline/src/components/EventPopup.tsx
@@ -83,18 +83,74 @@ export function EventPopup(_props: EventPopupProps) {
     };
   }, [selectedEvent, actions]);
 
-  // Close on Escape key
+  // Modal focus management: the popup is a `role="dialog" aria-modal="true"`,
+  // so keyboard focus must move into it on open, stay trapped inside while it is
+  // open (Tab/Shift+Tab wrap at the ends), and return to the element that opened
+  // it on close. Without this a keyboard user tabs into the page behind the
+  // dialog and the arrow/+/- timeline shortcuts keep firing under the modal.
   useEffect(() => {
     if (!selectedEvent) return;
+
+    // Remember what had focus (the triggering marker) so it can be restored.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    // All tabbable elements currently inside the popup, in DOM order.
+    const getFocusable = (): HTMLElement[] => {
+      const root = popupRef.current;
+      if (!root) return [];
+      return Array.from(
+        root.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])'
+        )
+      );
+    };
+
+    // Move focus into the dialog once it has rendered. Prefer the first
+    // interactive control (the close button); fall back to the dialog itself.
+    const focusTimer = setTimeout(() => {
+      const focusable = getFocusable();
+      (focusable[0] ?? popupRef.current)?.focus();
+    }, 0);
 
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         actions.setSelectedEvent(null);
+        return;
+      }
+      if (e.key !== 'Tab') return;
+
+      // Trap Tab inside the dialog.
+      const focusable = getFocusable();
+      if (focusable.length === 0) {
+        // Nothing tabbable but the dialog — keep focus on it.
+        e.preventDefault();
+        popupRef.current?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey) {
+        if (active === first || !popupRef.current?.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (active === last || !popupRef.current?.contains(active)) {
+        e.preventDefault();
+        first.focus();
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
+    return () => {
+      clearTimeout(focusTimer);
+      document.removeEventListener('keydown', handleKeyDown);
+      // Restore focus to the opener, if it is still in the document.
+      if (previouslyFocused && document.contains(previouslyFocused)) {
+        previouslyFocused.focus();
+      }
+    };
   }, [selectedEvent, actions]);
 
   // Calculate popup position after render
@@ -178,6 +234,7 @@ export function EventPopup(_props: EventPopupProps) {
       style={popupStyle}
       role="dialog"
       aria-modal="true"
+      tabIndex={-1}
       aria-labelledby="popup-title"
       aria-describedby={selectedEvent.description ? "popup-description" : undefined}
     >

--- a/packages/react-simile-timeline/src/hooks/usePan.test.ts
+++ b/packages/react-simile-timeline/src/hooks/usePan.test.ts
@@ -142,6 +142,39 @@ describe('usePan — keyboard', () => {
     pressKey('ArrowRight');
     expect(onPan).not.toHaveBeenCalled();
   });
+
+  it('with scopeRef, ignores arrows while focus is outside the scope', () => {
+    const onPan = vi.fn();
+    const scopeEl = document.createElement('div');
+    document.body.appendChild(scopeEl);
+    try {
+      renderHook(() =>
+        usePan({ onPan, pixelsPerMs: 1, keyboardPanAmount: 1000, scopeRef: { current: scopeEl } })
+      );
+      // Focus is on <body>, outside the scope element.
+      pressKey('ArrowRight');
+      expect(onPan).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeChild(scopeEl);
+    }
+  });
+
+  it('with scopeRef, pans while focus is inside the scope', () => {
+    const onPan = vi.fn();
+    const scopeEl = document.createElement('div');
+    scopeEl.tabIndex = 0;
+    document.body.appendChild(scopeEl);
+    scopeEl.focus();
+    try {
+      renderHook(() =>
+        usePan({ onPan, pixelsPerMs: 1, keyboardPanAmount: 1000, scopeRef: { current: scopeEl } })
+      );
+      pressKey('ArrowRight');
+      expect(onPan).toHaveBeenCalledWith(1000);
+    } finally {
+      document.body.removeChild(scopeEl);
+    }
+  });
 });
 
 describe('usePan — cleanup', () => {

--- a/packages/react-simile-timeline/src/hooks/usePan.ts
+++ b/packages/react-simile-timeline/src/hooks/usePan.ts
@@ -11,6 +11,13 @@ export interface UsePanOptions {
   onPanEnd?: () => void;
   /** Enable keyboard navigation */
   enableKeyboard?: boolean;
+  /**
+   * When set, keyboard panning only fires while focus is inside this element.
+   * Without it the arrow-key handler is global (legacy behavior). Scoping it to
+   * the focused timeline keeps an embedded timeline from hijacking the page's
+   * arrow keys, and stops arrows panning the band behind an open modal popup.
+   */
+  scopeRef?: React.RefObject<HTMLElement | null>;
   /** Milliseconds to pan per keyboard press */
   keyboardPanAmount?: number;
   /** Friction coefficient for momentum (0-1, lower = more friction) */
@@ -39,6 +46,7 @@ export function usePan({
   onPanStart,
   onPanEnd,
   enableKeyboard = true,
+  scopeRef,
   keyboardPanAmount = 24 * 60 * 60 * 1000, // 1 day default
   friction = 0.95,
   velocityThreshold = 0.01,
@@ -59,6 +67,7 @@ export function usePan({
   const pixelsPerMsRef = useRef(pixelsPerMs);
   const frictionRef = useRef(friction);
   const velocityThresholdRef = useRef(velocityThreshold);
+  const scopeRefRef = useRef(scopeRef);
 
   // Update refs when props change
   useEffect(() => {
@@ -68,7 +77,8 @@ export function usePan({
     pixelsPerMsRef.current = pixelsPerMs;
     frictionRef.current = friction;
     velocityThresholdRef.current = velocityThreshold;
-  }, [onPan, onPanStart, onPanEnd, pixelsPerMs, friction, velocityThreshold]);
+    scopeRefRef.current = scopeRef;
+  }, [onPan, onPanStart, onPanEnd, pixelsPerMs, friction, velocityThreshold, scopeRef]);
 
   // Cancel any ongoing momentum animation
   const cancelMomentum = useCallback(() => {
@@ -154,6 +164,11 @@ export function usePan({
       return;
     }
 
+    // Move keyboard focus to the band so the scoped arrow/zoom keys take effect
+    // after a pointer interaction. `preventDefault()` below would otherwise
+    // suppress the implicit focus; a no-op on bands that are not focusable.
+    (e.currentTarget as HTMLElement).focus({ preventScroll: true });
+
     // Cancel any ongoing momentum
     cancelMomentum();
 
@@ -189,6 +204,12 @@ export function usePan({
     const handleKeyDown = (e: KeyboardEvent) => {
       // Don't handle if focus is on an input
       if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      // When scoped, only pan while focus is inside the timeline band.
+      const scopeEl = scopeRefRef.current?.current;
+      if (scopeEl && !scopeEl.contains(document.activeElement)) {
         return;
       }
 

--- a/packages/react-simile-timeline/src/styles/timeline.css
+++ b/packages/react-simile-timeline/src/styles/timeline.css
@@ -53,6 +53,9 @@
   --event-text-shadow: 0 0 2px white, 0 0 2px white;
   --event-selected-ring-color: white;
 
+  /* Keyboard focus indicator (WCAG 2.4.7) */
+  --focus-ring-color: #1a73e8;
+
   /* Apply base styles */
   font-family: var(--timeline-font-family);
   background-color: var(--timeline-bg);
@@ -94,6 +97,8 @@
   --sticky-label-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
   --event-text-shadow: 0 0 2px #1a1a1a, 0 0 2px #1a1a1a;
   --event-selected-ring-color: #444;
+  /* Lighter ring for contrast against the dark surfaces */
+  --focus-ring-color: #8ab4f8;
 }
 
 /* Loading state */
@@ -128,6 +133,25 @@
 .timeline-band--detail {
   background-color: var(--band-bg);
   transition: background-color 0.3s ease;
+}
+
+/*
+ * Keyboard focus indicators (WCAG 2.4.7). Only shown for keyboard focus via
+ * :focus-visible, so a pointer press on the band does not draw a ring. The
+ * popup is portaled outside .timeline-root, so its ring uses a literal colour
+ * rather than the themed variable.
+ */
+.timeline-band:focus-visible,
+.timeline-event:focus-visible {
+  outline: 2px solid var(--focus-ring-color, #1a73e8);
+  outline-offset: 2px;
+}
+
+.timeline-popup:focus-visible,
+.timeline-popup a:focus-visible,
+.timeline-popup button:focus-visible {
+  outline: 2px solid #1a73e8;
+  outline-offset: 2px;
 }
 
 /* Event markers */


### PR DESCRIPTION
Executes **§1.2 keyboard operability** of the [v1.2.0 accessibility & final hardening plan](plans/2026-08-20-accessibility-and-final-hardening-plan.md) toward the WCAG 2.1 AA audit ([#25](https://github.com/thbst16/react-simile-timeline/issues/25)).

## What was wrong
The plan assumed the popup already had "focus trap + Escape." Audit found it had **Escape only** — no focus-in, no trap, no restore — and the pan/zoom keys were **global `window` listeners** that hijacked the host page's arrow/`+`/`-` keys and kept panning the band *behind* an open modal.

## Changes
- **Scoped pan/zoom to the focused timeline.** The primary band is now a single tab stop (`role=group`, `aria-keyshortcuts`, `tabindex=0`); arrows/`+`/`-` only fire while it (or a marker inside it) has focus. `usePan` gains an opt-in `scopeRef`; a pointer press focuses the band so the click-then-key path still works. An embedded timeline no longer steals the page's keys.
- **Popup is now a proper modal.** Focus moves into the dialog on open, `Tab`/`Shift+Tab` are trapped, and focus returns to the opening marker on close.
- **Keyboard-opened popup positioning.** Enter/Space activation anchored the popup to a synthetic pointer position → `NaN` coords. Now anchors to the marker's on-screen box.
- **Visible focus indicators.** Added themeable `:focus-visible` rings for the band, markers, and popup controls — there were none before (a latent 2.4.7 gap on the already-focusable markers).
- **Docs.** README now documents the accessible interaction path and tab order.

## Verification
- `pnpm lint`, `typecheck` clean.
- Unit: **122 passed** (added `usePan` `scopeRef` gating cases).
- e2e: **27 passed**, including a new `keyboard.spec.ts` (scoped pan/zoom, tab-stop, `marker → Enter → focus-trap → Escape → restore`) and the existing suite; the axe WCAG 2 A/AA gate stays green across default/dark/popup; "no console errors" confirms the `NaN` warning is gone.

Scope is library + demo e2e only. No public API change (only an additive optional `usePan` option). No release in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)