### PR TITLE
a11y remediation: screen-reader semantics + focus/contrast/motion (§1.3–§1.4, #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ When a popup opens, focus moves into the dialog and is trapped there until it
 closes; closing it (via `Escape` or the close button) restores focus to the
 marker that opened it.
 
+### Focus indicator
+
+Focusable elements show a visible focus ring when reached by keyboard. Its
+colour is the themeable `--focus-ring-color` CSS variable (classic `#1a73e8`,
+dark `#8ab4f8`); override it in a custom theme to keep the ring at least 3:1
+against your background.
+
+### Reduced motion
+
+The library honours `prefers-reduced-motion`. When a visitor has reduced motion
+enabled at the OS level, the event and popup fade-ins and the theme-change
+transitions are removed, and a pan stops immediately on release instead of
+gliding with momentum.
+
 ---
 
 ## Simile JSON Compatibility

--- a/demo/tests/reduced-motion.spec.ts
+++ b/demo/tests/reduced-motion.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+// Reduced motion (§1.4, WCAG 2.3.3). Verifies the library both animates by
+// default and drops its animations/transitions when the visitor asks for
+// reduced motion. Pan momentum is JavaScript-driven and disabled in usePan
+// under the same preference; this suite covers the CSS-driven motion, which is
+// what an emulated media query can assert deterministically.
+
+const firstMarkerAnimation = (page: import('@playwright/test').Page) =>
+  page.evaluate(() => {
+    const el = document.querySelector('.timeline-event');
+    return el ? getComputedStyle(el).animationName : null;
+  });
+
+test.describe('reduced motion', () => {
+  test('animates event markers by default', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await page.goto('/');
+    await page.locator('.timeline-event').first().waitFor();
+    // The fade-in keyframe animation is active.
+    expect(await firstMarkerAnimation(page)).toBe('event-fade-in');
+  });
+
+  test('removes animations and transitions when reduced motion is requested', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/');
+    await page.locator('.timeline-event').first().waitFor();
+
+    // Event fade-in is gone.
+    expect(await firstMarkerAnimation(page)).toBe('none');
+
+    // Theme-change transitions are gone on the themed root and bands.
+    const transitions = await page.evaluate(() => {
+      const root = document.querySelector('.timeline-root');
+      const band = document.querySelector('.timeline-band');
+      return {
+        root: root ? getComputedStyle(root).transitionDuration : null,
+        band: band ? getComputedStyle(band).transitionDuration : null,
+      };
+    });
+    expect(transitions.root).toBe('0s');
+    expect(transitions.band).toBe('0s');
+  });
+
+  test('removes the popup fade-in when reduced motion is requested', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.goto('/');
+    await page.locator('.timeline-event[role="button"]').first().click();
+    await expect(page.locator('.timeline-popup')).toBeVisible();
+    const anim = await page.evaluate(() => {
+      const el = document.querySelector('.timeline-popup');
+      return el ? getComputedStyle(el).animationName : null;
+    });
+    expect(anim).toBe('none');
+  });
+});

--- a/demo/tests/screenreader.spec.ts
+++ b/demo/tests/screenreader.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+// Screen-reader semantics (§1.3). Asserts the name/role/value data that a
+// screen reader consumes: the timeline is a labelled region, the event
+// collection is a named group, markers announce title + date, and the
+// decorative mini-map / time axis are hidden from the accessibility tree so
+// events are not announced two or three times. This is the automated proxy for
+// the manual two-reader pass (VoiceOver + NVDA/Orca), not a replacement for it.
+
+test.describe('screen-reader semantics', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-testid="timeline-container"]').first().waitFor();
+  });
+
+  test('the timeline is exposed as a labelled region', async ({ page }) => {
+    await expect(
+      page.getByRole('region', { name: 'Timeline visualization' }).first()
+    ).toBeVisible();
+  });
+
+  test('the event collection is a named group', async ({ page }) => {
+    await expect(
+      page.getByRole('group', { name: /Timeline events, \d+ in view/ }).first()
+    ).toBeVisible();
+  });
+
+  test('event markers announce their title and date', async ({ page }) => {
+    const marker = page.locator('.timeline-event[role="button"]').first();
+    await marker.waitFor();
+    const name = await marker.getAttribute('aria-label');
+    // Name carries a real calendar date (a four-digit year), not just a title.
+    expect(name).toMatch(/\b\d{4}\b/);
+  });
+
+  test('the time axis is hidden from the accessibility tree', async ({ page }) => {
+    // Every scale is decorative; the marker names carry the dates.
+    const scales = page.locator('.timeline-scale');
+    const count = await scales.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(scales.nth(i)).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  test('the overview mini-map is hidden from the accessibility tree', async ({ page }) => {
+    const overviews = page.locator('.timeline-overview-markers');
+    const count = await overviews.count();
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      await expect(overviews.nth(i)).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  test('an annotated hot zone is exposed as a note', async ({ page }) => {
+    // The Hot Zones demo carries annotated periods.
+    await expect(page.getByRole('note').first()).toBeVisible();
+  });
+});

--- a/packages/react-simile-timeline/README.md
+++ b/packages/react-simile-timeline/README.md
@@ -241,6 +241,20 @@ When a popup opens, focus moves into the dialog and is trapped there until it
 closes; closing it (via `Escape` or the close button) restores focus to the
 marker that opened it.
 
+### Focus indicator
+
+Focusable elements show a visible focus ring when reached by keyboard. Its
+colour is the themeable `--focus-ring-color` CSS variable (classic `#1a73e8`,
+dark `#8ab4f8`); override it in a custom theme to keep the ring at least 3:1
+against your background.
+
+### Reduced motion
+
+The library honours `prefers-reduced-motion`. When a visitor has reduced motion
+enabled at the OS level, the event and popup fade-ins and the theme-change
+transitions are removed, and a pan stops immediately on release instead of
+gliding with momentum.
+
 ---
 
 ## Simile JSON Compatibility

--- a/packages/react-simile-timeline/src/components/EventMarker.test.tsx
+++ b/packages/react-simile-timeline/src/components/EventMarker.test.tsx
@@ -34,16 +34,34 @@ describe('EventMarker — accessibility', () => {
     expect(marker).toHaveAttribute('tabindex', '0');
   });
 
-  it('folds the description into the accessible label', () => {
+  it('folds the date and description into the accessible label', () => {
     renderMarker();
     expect(
-      screen.getByRole('button', { name: 'Launch: Ship it' })
+      screen.getByRole('button', { name: 'Launch, Jan 15, 2023: Ship it' })
     ).toBeInTheDocument();
   });
 
   it('renders the title text', () => {
     renderMarker();
     expect(screen.getByText('Launch')).toBeInTheDocument();
+  });
+
+  it('announces a date range for duration events', () => {
+    const durationEvent: TimelineEvent = {
+      start: '2023-01-15',
+      end: '2023-03-20',
+      title: 'Phase',
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TimelineProvider events={[durationEvent]}>{children}</TimelineProvider>
+    );
+    render(
+      <EventMarker event={durationEvent} x={10} y={20} isDuration durationWidth={80} />,
+      { wrapper }
+    );
+    expect(
+      screen.getByRole('button', { name: 'Phase, Jan 15, 2023 to Mar 20, 2023' })
+    ).toBeInTheDocument();
   });
 });
 

--- a/packages/react-simile-timeline/src/components/EventMarker.tsx
+++ b/packages/react-simile-timeline/src/components/EventMarker.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import type { TimelineEvent } from '../types';
 import { useTimelineContext } from './TimelineProvider';
+import { formatDate, parseDate } from '../utils/dateUtils';
 
 export interface EventMarkerProps {
   /** The event to render */
@@ -70,10 +71,23 @@ export function EventMarker({
   const color = event.color || (isDuration ? DEFAULT_TAPE_COLOR : DEFAULT_COLOR);
   const textColor = event.textColor || 'var(--event-text-color, #333)';
 
-  // Construct accessible label
-  const ariaLabel = event.description
-    ? `${event.title}: ${event.description.substring(0, 100)}${event.description.length > 100 ? '...' : ''}`
-    : event.title;
+  // Construct the accessible name: title, then the date (or range) so a screen
+  // reader announces *when* the event is, then a trimmed description. The date
+  // is what a sighted user reads from the marker's horizontal position, so it
+  // belongs in the name for a non-visual reader.
+  let dateLabel = event.start;
+  try {
+    dateLabel = formatDate(parseDate(event.start), 'MMM d, yyyy');
+    if (event.end) {
+      dateLabel += ` to ${formatDate(parseDate(event.end), 'MMM d, yyyy')}`;
+    }
+  } catch {
+    // Fall back to the raw start string for unparseable dates.
+  }
+  const descriptionPart = event.description
+    ? `: ${event.description.substring(0, 100)}${event.description.length > 100 ? '...' : ''}`
+    : '';
+  const ariaLabel = `${event.title}, ${dateLabel}${descriptionPart}`;
 
   // Render duration event as a tape/bar
   if (isDuration && durationWidth) {

--- a/packages/react-simile-timeline/src/components/EventTrack.tsx
+++ b/packages/react-simile-timeline/src/components/EventTrack.tsx
@@ -64,6 +64,11 @@ export function EventTrack({
   return (
     <div
       className="timeline-event-track"
+      // Name the collection of event markers so a screen reader announces the
+      // grouping (and, via the live count, how many are in view) before the
+      // reader steps through the individual event buttons.
+      role="group"
+      aria-label={`Timeline events, ${layoutEvents.length} in view`}
       style={{
         position: 'relative',
         width: '100%',

--- a/packages/react-simile-timeline/src/components/HotZones.tsx
+++ b/packages/react-simile-timeline/src/components/HotZones.tsx
@@ -89,6 +89,12 @@ export function HotZones({
         <div
           key={`hotzone-${index}-${hz.zone.start}`}
           className="timeline-hot-zone"
+          // An annotated zone conveys information (a named period), so expose it
+          // as a note carrying that text. An un-annotated zone is a purely
+          // decorative background highlight and is hidden from the tree.
+          {...(hz.annotation
+            ? { role: 'note', 'aria-label': `${hz.annotation} period` }
+            : { 'aria-hidden': true })}
           style={{
             position: 'absolute',
             left: hz.x,
@@ -104,6 +110,9 @@ export function HotZones({
           {hz.annotation && (
             <div
               className="timeline-hot-zone__annotation"
+              // The parent note's aria-label already carries this text; hide the
+              // visual copy so it is not announced twice.
+              aria-hidden="true"
               style={{
                 position: 'absolute',
                 bottom: 28, // Above the 24px time scale

--- a/packages/react-simile-timeline/src/components/OverviewMarkers.tsx
+++ b/packages/react-simile-timeline/src/components/OverviewMarkers.tsx
@@ -53,6 +53,10 @@ export function OverviewMarkers({
   return (
     <div
       className="timeline-overview-markers"
+      // The overview band is a visual mini-map of the same events shown in the
+      // detail band. Exposing these duplicate markers would announce every
+      // event twice, so the overview is hidden from the accessibility tree.
+      aria-hidden="true"
       style={{
         position: 'relative',
         width: '100%',

--- a/packages/react-simile-timeline/src/components/TimeScale.tsx
+++ b/packages/react-simile-timeline/src/components/TimeScale.tsx
@@ -46,6 +46,10 @@ export function TimeScale({
   return (
     <div
       className="timeline-scale"
+      // The time axis is a visual orientation aid; every event marker already
+      // announces its own date, so reading each tick label would be noise.
+      // Hidden from the accessibility tree as decoration.
+      aria-hidden="true"
       style={{
         position: 'relative',
         width: '100%',

--- a/packages/react-simile-timeline/src/hooks/usePan.test.ts
+++ b/packages/react-simile-timeline/src/hooks/usePan.test.ts
@@ -177,6 +177,37 @@ describe('usePan — keyboard', () => {
   });
 });
 
+describe('usePan — reduced motion', () => {
+  it('skips release momentum when the user prefers reduced motion', () => {
+    // jsdom has no matchMedia; install one that reports the reduce preference.
+    const mql = {
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+    (window as unknown as { matchMedia: unknown }).matchMedia = vi
+      .fn()
+      .mockReturnValue(mql);
+    // Keep momentum from actually recursing across frames in the test.
+    const rafSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation(() => 0);
+    try {
+      const { result } = renderHook(() => usePan({ onPan: vi.fn(), pixelsPerMs: 1 }));
+      act(() => result.current.panProps.onPointerDown(pointerDownArg({ clientX: 100 })));
+      dispatchPointer('pointermove', 140); // build velocity
+      rafSpy.mockClear();
+      dispatchPointer('pointerup', 140);
+      // No momentum animation scheduled on release.
+      expect(rafSpy).not.toHaveBeenCalled();
+    } finally {
+      rafSpy.mockRestore();
+      delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+    }
+  });
+});
+
 describe('usePan — cleanup', () => {
   let addSpy: ReturnType<typeof vi.spyOn>;
   let removeSpy: ReturnType<typeof vi.spyOn>;

--- a/packages/react-simile-timeline/src/hooks/usePan.ts
+++ b/packages/react-simile-timeline/src/hooks/usePan.ts
@@ -37,6 +37,18 @@ export interface UsePanResult {
 }
 
 /**
+ * Whether the user has asked for reduced motion. Guarded for non-browser and
+ * jsdom environments where matchMedia may be absent.
+ */
+function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}
+
+/**
  * Hook for handling pan/drag interactions with momentum
  * Uses refs to avoid stale closure issues with event listeners
  */
@@ -144,8 +156,11 @@ export function usePan({
       }
     }
 
-    // Start momentum animation
-    animateMomentum();
+    // Start momentum animation — unless the user prefers reduced motion, in
+    // which case the pan stops dead on release with no inertial glide.
+    if (!prefersReducedMotion()) {
+      animateMomentum();
+    }
 
     // Remove listeners - these are the SAME function references that were added
     document.removeEventListener('pointermove', handlePointerMove);

--- a/packages/react-simile-timeline/src/styles/timeline.css
+++ b/packages/react-simile-timeline/src/styles/timeline.css
@@ -236,3 +236,19 @@
   pointer-events: none;
 }
 
+/*
+ * Respect the user's reduced-motion preference (WCAG 2.3.3). Removes the
+ * event/popup fade-ins and the theme-change transitions. The popup is portaled
+ * to <body>, outside .timeline-root, so it is targeted explicitly. Pan momentum
+ * is JavaScript-driven and disabled separately in usePan.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .timeline-root,
+  .timeline-root *,
+  .timeline-popup,
+  .timeline-popup * {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+


### PR DESCRIPTION
Executes **§1.3 (screen-reader semantics)** and **§1.4 (visible focus, contrast, reduced motion)** of the [v1.2.0 accessibility & final hardening plan](plans/2026-08-20-accessibility-and-final-hardening-plan.md) toward the WCAG 2.1 AA audit ([#25](https://github.com/thbst16/react-simile-timeline/issues/25)).

Follows #76 (§1.2 keyboard), now merged. Rebased onto `main`, so the diff is §1.3–§1.4 only.

## §1.3 — screen-reader semantics
Six of nine components had no ARIA, and the overview band + per-band axis re-exposed the same events, so a reader announced each event 2–3× plus every tick label.

| Component | Change |
|---|---|
| `EventMarker` | Accessible name now carries **title + date** (full range for durations) |
| `EventTrack` | Event layer is a named `group` — "Timeline events, N in view" |
| `OverviewMarkers` | Decorative mini-map → `aria-hidden` |
| `TimeScale` | Decorative axis → `aria-hidden` |
| `HotZones` | Annotated zone → `role=note`; un-annotated → `aria-hidden` |

## §1.4 — visible focus, contrast, motion
- **Reduced motion (net-new, WCAG 2.3.3):** a `prefers-reduced-motion: reduce` block removes the event/popup fade-ins and theme transitions (the portaled popup is targeted explicitly); `usePan` skips release momentum so a pan stops dead.
- **Focus indicators:** added in #76; the ring is the themeable `--focus-ring-color` (classic `#1a73e8`, dark `#8ab4f8`), now documented.
- **Contrast:** audited every default text/UI token pair for both themes. All text pairs pass (min **5.50:1** vs 4.5) and all interactive/meaningful-graphic pairs pass 3:1 (focus rings 4.13–6.81, event dots 3.34–4.29). The only sub-3:1 pairs are the thin band-divider borders — decorative separators exempt under 1.4.11. No token change needed.

## Verification
- `pnpm lint`, `typecheck` clean.
- Unit: **127 passed** (marker date/range names; usePan reduced-motion); coverage 77%.
- e2e: **36 passed**, including new `screenreader.spec.ts` (region/group/note roles, marker date names, hidden decoration — asserted against the browser accessibility tree) and `reduced-motion.spec.ts` (animations active by default, removed under an emulated reduce preference). Axe WCAG 2 A/AA gate green across default/dark/popup.

## Not in this PR
The **manual two-reader pass** (VoiceOver + NVDA/Orca) is the maintainer's gate per the plan; this is the semantic + motion groundwork it consumes. §1.5 (conformance statement + restored AA claim) comes only after §1.1–§1.4 pass and that manual pass is clean.

Library + demo e2e only. No public API change. No release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)