### PR TITLE
fix(lint): disable React 19-only @eslint-react context rules for the React 18 floor

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,16 @@ export default tseslint.config(
       '@eslint-react/web-api-no-leaked-fetch': 'off',
       '@eslint-react/use-state': 'off',
 
+      // These two suggest React 19-only forms - rendering `<Context>` directly
+      // as a provider, and the `use` hook in place of `useContext`. Neither
+      // exists in React 18, and the library's peer range is `^18 || ^19`, so the
+      // current `<Context.Provider>` / `useContext` usage is required, not a
+      // style choice. They are disabled so lint stays deterministic: @eslint-react
+      // only fires them when it detects React 19, and that detection varies with
+      // install hoisting, which made CI lint intermittently red.
+      '@eslint-react/no-context-provider': 'off',
+      '@eslint-react/no-use-context': 'off',
+
       // React Hooks
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',


### PR DESCRIPTION
## Problem
`build-and-test (node 20, TZ UTC)` failed lint on #79 with two warnings on `TimelineProvider.tsx`, while the identical code passed lint on every other matrix leg, on the React-18 peer-floor job, and locally — and on the previously-merged #76 and #78.

The two rules — `@eslint-react/no-context-provider` and `@eslint-react/no-use-context` — only fire when `@eslint-react` **detects React 19**, and that detection depends on install hoisting. So `eslint . --max-warnings=0` was **intermittently** red.

## Why the rules are wrong here anyway
They suggest React 19-only forms — rendering `<Context>` directly as a provider, and the `use` hook in place of `useContext`. **Neither exists in React 18.** The library's peer range is `^18 || ^19`, so the current `<Context.Provider>` / `useContext` usage is *required*, not a style choice. Adopting the suggested forms would break the React 18 floor the peer-floor CI job guards.

## Fix
Disable both rules, alongside the existing [#72](https://github.com/thbst16/react-simile-timeline/issues/72) block of expanded `@eslint-react` rules. Lint is now deterministic and matches the supported React range.

`pnpm lint` clean. Config only — no source, no tests, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)