### PR TITLE
release: 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Planned
+
+- Zone magnification effect
+- Visual regression testing
+
+## [1.2.0] - 2026-08-20
+
 ### Added
 
 - **WCAG 2.1 AA conformance, audited and remediated
@@ -31,10 +38,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`prefers-reduced-motion` is honoured** — fade-ins, theme transitions, and
     pan momentum are removed when the visitor asks for reduced motion.
 
-### Planned
+### Changed
 
-- Zone magnification effect
-- Visual regression testing
+- **Build toolchain: pnpm 9 → 10 and ESLint 9 → 10.** ESLint moved to 10 with
+  `@eslint-react/eslint-plugin` replacing the unmaintained-on-ESLint-10
+  `eslint-plugin-react` ([#54](https://github.com/thbst16/react-simile-timeline/issues/54)),
+  which also dissolved the `brace-expansion`/`minimatch` override hazard
+  ([#61](https://github.com/thbst16/react-simile-timeline/issues/61)). Dev-only
+  and build-internal — no runtime API, props, or exports changed.
+
+### Security
+
+- **All dependency advisories cleared.** The last remaining advisory —
+  `esbuild@0.21.5`, a dev-only Vite optional peer that was unmovable under
+  pnpm 9 — is resolved by the pnpm 10 upgrade
+  ([#52](https://github.com/thbst16/react-simile-timeline/issues/52)).
+  `pnpm audit` now reports no known vulnerabilities.
 
 ## [1.1.1] - 2026-08-19
 

--- a/packages/react-simile-timeline/package.json
+++ b/packages/react-simile-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simile-timeline",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "A modern React implementation of the MIT SIMILE Timeline visualization component. Create interactive, multi-band timelines with point and duration events, hot zones, themes, and 100% Simile JSON compatibility.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump for the **1.2.0** release (§5 of the [v1.2.0 plan](plans/2026-08-20-accessibility-and-final-hardening-plan.md)).

- `packages/react-simile-timeline/package.json`: `1.1.1` → `1.2.0`
- CHANGELOG: `[Unreleased]` accessibility work closed as `[1.2.0] - 2026-08-20`, with the toolchain and security changes (pnpm 10, ESLint 10, cleared `esbuild` advisory) folded into the same entry.

## What 1.2.0 is
The accessibility and final-hardening release:
- **WCAG 2.1 AA conformance** — audited, remediated, and documented in [ACCESSIBILITY.md](ACCESSIBILITY.md) (#25, via #75/#76/#78/#79).
- **Toolchain** — pnpm 9 → 10 clearing the last dependency advisory (#52), ESLint 9 → 10 via `@eslint-react` (#54). `pnpm audit` reports zero vulnerabilities.

No runtime API, props, or exports changed since 1.1.1 — the public surface is identical; this is additive accessibility behavior plus dev/build-internal hardening.

## Release sequence (owner-applied)
This PR only bumps the version. Per your OIDC choice, the publish path is:
1. Register the trusted publisher on npmjs.com (Settings → Trusted Publishing; GitHub Actions / `thbst16/react-simile-timeline` / `release.yml`).
2. Merge this PR.
3. Run the **preflight** (Actions → Release → Run workflow) to confirm npm is OIDC-capable.
4. Merge #63 (removes `NPM_TOKEN` from the workflow).
5. `git tag v1.2.0 && git push origin v1.2.0` — publishes via OIDC with provenance. **Irreversible**; the tag must match `package.json` (the workflow guards this).
6. After a confirmed OIDC release, `gh secret delete NPM_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)