### PR TITLE
fix(release): drop registry-url so OIDC publish isn't shadowed by an empty token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,12 +104,19 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
+      # NOTE: `registry-url` is deliberately NOT set here. When it is,
+      # actions/setup-node writes an .npmrc with `always-auth=true` and
+      # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. With no token
+      # (there is none under OIDC), npm sends an empty credential and the
+      # registry returns `404 Not Found - PUT` instead of falling through to the
+      # OIDC exchange. Omitting registry-url leaves no auth line, so npm's own
+      # trusted-publishing flow runs. Publishing still targets the default
+      # registry (registry.npmjs.org).
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
 
       # The runner's Node 20 ships npm 10.8.2; OIDC trusted publishing needs
       # >= 11.5.1. Pinned to 11.x for reproducibility rather than @latest.


### PR DESCRIPTION
## Symptom
`v1.2.0` publish fails at the registry with:
```
npm error 404 Not Found - PUT https://registry.npmjs.org/react-simile-timeline
```
…**after** packing correctly and signing provenance via OIDC. Reproduced on three runs.

## Cause
The publish job's `actions/setup-node` set `registry-url`, which writes an `.npmrc` containing `always-auth=true` and `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. Under OIDC trusted publishing there is **no** token, so npm sends an empty credential and the registry returns `404 PUT` instead of running the OIDC exchange. (The `npm warn Unknown user config "always-auth"` line in the failed logs is the tell.)

## Fix
Remove `registry-url` from the publish job's Node setup. No auth line is written, so npm's trusted-publishing flow runs. Publishing still targets the default registry (`registry.npmjs.org`). Provenance and `id-token: write` are unchanged.

Config-only. After merge, the `v1.2.0` tag moves to the new HEAD and the release re-runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)