### PR TITLE
fix(demo): dedupe React so the production build doesn't render blank

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,8 +227,13 @@ jobs:
       - name: Build demo
         run: pnpm --filter demo build
 
+      # Run the suite against the built bundle served by `vite preview`, not the
+      # dev server, so a production-only rendering fault fails CI here rather
+      # than in a Vercel deploy. The build step above produced demo/dist.
       - name: E2E tests
         run: pnpm test:e2e
+        env:
+          E2E_PREVIEW: '1'
 
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4

--- a/demo/playwright.config.ts
+++ b/demo/playwright.config.ts
@@ -25,8 +25,16 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
+  // With E2E_PREVIEW=1, run the tests against the PRODUCTION build served by
+  // `vite preview` instead of the dev server. The dev server dedupes React on
+  // its own, so a production-only bundling fault (e.g. two React copies) renders
+  // blank in production while every dev-mode test passes. CI sets this flag so
+  // the suite exercises the bundle Vercel actually ships. Requires the demo to
+  // be built first (the CI job builds it before this step).
   webServer: {
-    command: 'pnpm dev',
+    command: process.env.E2E_PREVIEW
+      ? 'pnpm preview --port 3000 --strictPort'
+      : 'pnpm dev',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     alias: {
       '@': resolve(__dirname, './src'),
     },
+    // Force a single React copy into the bundle. The workspace also carries
+    // React 19 (the library's own dev/test dependency); without deduping, the
+    // production build resolves the library's `react` import to 19 while the
+    // demo app uses its declared React 18, bundling two Reacts. The second
+    // React's dispatcher is never initialised, so the first hook call throws
+    // "Cannot read properties of null (reading 'useState')" and the page is
+    // blank. Dev mode dedupes on its own; the production rollup does not.
+    dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
   },
   server: {
     port: 3000,


### PR DESCRIPTION
## Symptom
The deployed demo (react-simile-timeline-demo.vercel.app) renders **blank** with:
```
TypeError: Cannot read properties of null (reading 'useState')
```

## Cause
The production bundle contained **two React copies**. The demo declares React 18 (resolves 18.3.1), but the workspace also carries **React 19.2.8** — the library's own dev/test dependency. The production rollup resolved the library's `react` import to 19 while the demo app used 18. Only one React's dispatcher is initialised per render, so the hook call against the other React hit a `null` dispatcher and nothing mounted. (Confirmed in the bundle: both `.current.useState` (React 18) and `.H.useState` (React 19) dispatcher patterns were present.)

## Why every check was green
The e2e suite ran only against `pnpm dev`. Vite's dev server dedupes React automatically, so the fault was **production-only** and invisible to every test.

## Fix
- `resolve.dedupe: ['react','react-dom','react/jsx-runtime']` in `demo/vite.config.ts` → a single React in the bundle. Bundle drops 211 KB → 202 KB (one fewer React); the built `vite preview` renders with **no console errors**.
- **Guard:** the e2e suite now runs against the `vite preview` **production build** in CI (`E2E_PREVIEW=1`) — the bundle Vercel ships — so a blank production build fails CI here instead of in a deploy. Verified locally: 23 prod-mode e2e pass with the fix.

Merging redeploys the demo on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)