### PR TITLE
fix(demo): update hero badge to v1.2.0

### DIFF
--- a/demo/src/components/Hero.tsx
+++ b/demo/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export function Hero() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-600"></span>
             </span>
-            v1.0.2 Released
+            v1.2.0 Released
           </div>
 
           {/* Headline */}


### PR DESCRIPTION
The landing-page hero badge was hardcoded at **v1.0.2**, several releases stale. Updates it to **v1.2.0** (the current published version).

One-line demo copy change. Merging redeploys the demo on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)