### PR TITLE
feat(demo): rebrand the site on daisyUI's corporate theme (§1)

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="corporate">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -32,8 +32,8 @@
     <meta property="twitter:image" content="https://react-simile-timeline.vercel.app/og-image.png" />
 
     <!-- Theme Color -->
-    <meta name="theme-color" content="#3b82f6" />
-    <meta name="msapplication-TileColor" content="#3b82f6" />
+    <meta name="theme-color" content="#4b6bfb" />
+    <meta name="msapplication-TileColor" content="#4b6bfb" />
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://react-simile-timeline.vercel.app/" />

--- a/demo/package.json
+++ b/demo/package.json
@@ -24,6 +24,7 @@
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.4.0",
+    "daisyui": "^4.12.24",
     "postcss": "^8.5.23",
     "tailwindcss": "^3.4.0",
     "typescript": "~6.0.3",

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -181,7 +181,7 @@ function App() {
   const [theme, setTheme] = useState<'classic' | 'dark' | Theme>('classic');
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-base-200">
       <Header />
       <Hero />
 
@@ -189,8 +189,8 @@ function App() {
       <section id="demos" className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900">Interactive Demos</h2>
-            <p className="mt-4 text-xl text-gray-600 max-w-2xl mx-auto">
+            <h2 className="text-3xl sm:text-4xl font-bold text-base-content">Interactive Demos</h2>
+            <p className="mt-4 text-xl text-base-content/80 max-w-2xl mx-auto">
               Explore the Timeline component with these live examples. Drag to pan, scroll to zoom, and click events for details.
             </p>
           </div>
@@ -215,7 +215,7 @@ function App() {
                 <button
                   onClick={() => setTheme('classic')}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    theme === 'classic' ? 'bg-blue-600 text-white' : 'bg-white text-gray-700 border border-gray-300'
+                    theme === 'classic' ? 'bg-primary text-primary-content' : 'bg-base-100 text-base-content border border-base-300'
                   }`}
                 >
                   Classic
@@ -223,7 +223,7 @@ function App() {
                 <button
                   onClick={() => setTheme('dark')}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    theme === 'dark' ? 'bg-gray-800 text-white' : 'bg-white text-gray-700 border border-gray-300'
+                    theme === 'dark' ? 'bg-neutral text-neutral-content' : 'bg-base-100 text-base-content border border-base-300'
                   }`}
                 >
                   Dark
@@ -231,7 +231,7 @@ function App() {
                 <button
                   onClick={() => setTheme(customTheme)}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
-                    typeof theme === 'object' ? 'bg-sky-600 text-white' : 'bg-white text-gray-700 border border-gray-300'
+                    typeof theme === 'object' ? 'bg-accent text-accent-content' : 'bg-base-100 text-base-content border border-base-300'
                   }`}
                 >
                   Ocean (Custom)
@@ -267,22 +267,22 @@ function App() {
       </section>
 
       {/* Installation Section */}
-      <section id="installation" className="py-20 bg-white">
+      <section id="installation" className="py-20 bg-base-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900">Get Started</h2>
-            <p className="mt-4 text-xl text-gray-600 max-w-2xl mx-auto">
+            <h2 className="text-3xl sm:text-4xl font-bold text-base-content">Get Started</h2>
+            <p className="mt-4 text-xl text-base-content/80 max-w-2xl mx-auto">
               Install the package and start building beautiful timelines in minutes.
             </p>
           </div>
 
           <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
             <div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">1. Install the package</h3>
+              <h3 className="text-lg font-semibold text-base-content mb-4">1. Install the package</h3>
               <CodeBlock code={installationCode} language="bash" title="Installation Commands" />
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">2. Import and use</h3>
+              <h3 className="text-lg font-semibold text-base-content mb-4">2. Import and use</h3>
               <CodeBlock code={quickStartCode} language="tsx" title="Quick Start Example" />
             </div>
           </div>
@@ -293,77 +293,77 @@ function App() {
       <section id="api" className="py-20">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900">API Reference</h2>
-            <p className="mt-4 text-xl text-gray-600 max-w-2xl mx-auto">
+            <h2 className="text-3xl sm:text-4xl font-bold text-base-content">API Reference</h2>
+            <p className="mt-4 text-xl text-base-content/80 max-w-2xl mx-auto">
               Full TypeScript support with comprehensive prop types.
             </p>
           </div>
 
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden max-w-4xl mx-auto">
+          <div className="bg-base-100 rounded-2xl shadow-sm border border-base-300 overflow-hidden max-w-4xl mx-auto">
             <div className="overflow-x-auto">
               <table className="w-full text-left">
-                <thead className="bg-gray-50 border-b border-gray-200">
+                <thead className="bg-base-200 border-b border-base-300">
                   <tr>
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-900">Prop</th>
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-900">Type</th>
-                    <th className="px-6 py-4 text-sm font-semibold text-gray-900">Description</th>
+                    <th className="px-6 py-4 text-sm font-semibold text-base-content">Prop</th>
+                    <th className="px-6 py-4 text-sm font-semibold text-base-content">Type</th>
+                    <th className="px-6 py-4 text-sm font-semibold text-base-content">Description</th>
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-200">
+                <tbody className="divide-y divide-base-300">
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">data</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">TimelineData</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Inline timeline data object</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">data</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">TimelineData</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Inline timeline data object</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">dataUrl</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">string</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">URL to fetch timeline JSON data</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">dataUrl</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">string</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">URL to fetch timeline JSON data</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">height</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">number</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Timeline height in pixels</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">height</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">number</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Timeline height in pixels</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">bands</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">BandConfig[]</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Custom band configuration</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">bands</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">BandConfig[]</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Custom band configuration</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">theme</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">{`'classic' | 'dark' | Theme`}</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Built-in or custom theme</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">theme</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">{`'classic' | 'dark' | Theme`}</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Built-in or custom theme</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">hotZones</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">HotZone[]</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Highlighted time periods</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">hotZones</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">HotZone[]</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Highlighted time periods</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">centerDate</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">string</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Date to center the view on</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">centerDate</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">string</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Date to center the view on</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">onEventClick</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">(event) =&gt; void</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Event click callback</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">onEventClick</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">(event) =&gt; void</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Event click callback</td>
                   </tr>
                   <tr>
-                    <td className="px-6 py-4 font-mono text-sm text-blue-600">branding</td>
-                    <td className="px-6 py-4 font-mono text-sm text-gray-600">boolean | BrandingConfig</td>
-                    <td className="px-6 py-4 text-sm text-gray-600">Show branding watermark</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content">branding</td>
+                    <td className="px-6 py-4 font-mono text-sm text-base-content/80">boolean | BrandingConfig</td>
+                    <td className="px-6 py-4 text-sm text-base-content/80">Show branding watermark</td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <div className="p-6 bg-gray-50 border-t border-gray-200">
+            <div className="p-6 bg-base-200 border-t border-base-300">
               <a
                 href="https://github.com/thbst16/react-simile-timeline#api-reference"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-blue-600 hover:text-blue-700 font-medium flex items-center gap-2"
+                className="link link-hover text-base-content font-medium flex items-center gap-2"
               >
                 View full API documentation on GitHub
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -376,12 +376,12 @@ function App() {
       </section>
 
       {/* CTA Section */}
-      <section className="py-20 bg-gradient-to-r from-blue-600 to-indigo-600">
+      <section className="py-20 bg-gradient-to-r from-primary to-secondary">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-6">
+          <h2 className="text-3xl sm:text-4xl font-bold text-primary-content mb-6">
             Ready to build amazing timelines?
           </h2>
-          <p className="text-xl text-blue-100 mb-10 max-w-2xl mx-auto">
+          <p className="text-xl text-primary-content/80 mb-10 max-w-2xl mx-auto">
             Get started with React Simile Timeline today. It&apos;s free, open source, and ready for production.
           </p>
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
@@ -389,7 +389,7 @@ function App() {
               href="https://github.com/thbst16/react-simile-timeline"
               target="_blank"
               rel="noopener noreferrer"
-              className="w-full sm:w-auto px-8 py-4 bg-white text-blue-600 rounded-xl hover:bg-blue-50 transition-colors font-semibold text-lg flex items-center justify-center gap-2"
+              className="w-full sm:w-auto px-8 py-4 bg-base-100 text-base-content rounded-xl hover:bg-base-200 transition-colors font-semibold text-lg flex items-center justify-center gap-2"
             >
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
@@ -400,7 +400,7 @@ function App() {
               href="https://www.npmjs.com/package/react-simile-timeline"
               target="_blank"
               rel="noopener noreferrer"
-              className="w-full sm:w-auto px-8 py-4 bg-blue-700 text-white rounded-xl hover:bg-blue-800 transition-colors font-semibold text-lg border border-blue-500"
+              className="w-full sm:w-auto px-8 py-4 bg-base-100/15 text-primary-content rounded-xl hover:bg-base-100/25 transition-colors font-semibold text-lg border border-primary-content/30"
             >
               npm install react-simile-timeline
             </a>

--- a/demo/src/components/CodeBlock.tsx
+++ b/demo/src/components/CodeBlock.tsx
@@ -17,11 +17,11 @@ export function CodeBlock({ code, language = 'tsx', title }: CodeBlockProps) {
   };
 
   return (
-    <div className="mt-4 border border-gray-200 rounded-lg overflow-hidden">
-      <div className="flex items-center justify-between px-4 py-2 bg-gray-50 border-b border-gray-200">
+    <div className="mt-4 border border-base-300 rounded-lg overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2 bg-base-200 border-b border-base-300">
         <button
           onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-2 text-sm font-medium text-gray-700 hover:text-gray-900 transition-colors"
+          className="flex items-center gap-2 text-sm font-medium text-base-content/80 hover:text-base-content transition-colors"
         >
           <svg
             className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
@@ -34,10 +34,10 @@ export function CodeBlock({ code, language = 'tsx', title }: CodeBlockProps) {
           {title || 'View Source Code'}
         </button>
         <div className="flex items-center gap-2">
-          <span className="text-xs text-gray-700 bg-gray-200 px-2 py-1 rounded">{language}</span>
+          <span className="text-xs text-base-content/80 bg-base-300 px-2 py-1 rounded">{language}</span>
           <button
             onClick={handleCopy}
-            className="text-xs text-gray-500 hover:text-gray-700 transition-colors flex items-center gap-1"
+            className="text-xs text-base-content/80 hover:text-base-content transition-colors flex items-center gap-1"
           >
             {copied ? (
               <>
@@ -58,7 +58,7 @@ export function CodeBlock({ code, language = 'tsx', title }: CodeBlockProps) {
         </div>
       </div>
       {isExpanded && (
-        <pre className="p-4 bg-gray-900 text-gray-100 text-sm overflow-x-auto">
+        <pre className="p-4 bg-neutral text-neutral-content text-sm overflow-x-auto">
           <code>{code}</code>
         </pre>
       )}

--- a/demo/src/components/DemoSection.tsx
+++ b/demo/src/components/DemoSection.tsx
@@ -10,12 +10,12 @@ interface DemoSectionProps {
 
 export function DemoSection({ title, description, children, code }: DemoSectionProps) {
   return (
-    <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
-      <div className="p-6 border-b border-gray-100">
-        <h3 className="text-xl font-semibold text-gray-900">{title}</h3>
-        <p className="mt-2 text-gray-600">{description}</p>
+    <div className="bg-base-100 rounded-2xl shadow-sm border border-base-300 overflow-hidden">
+      <div className="p-6 border-b border-base-200">
+        <h3 className="text-xl font-semibold text-base-content">{title}</h3>
+        <p className="mt-2 text-base-content/80">{description}</p>
       </div>
-      <div className="p-6 bg-gray-50">
+      <div className="p-6 bg-base-200">
         {children}
       </div>
       <div className="px-6 pb-6">

--- a/demo/src/components/Footer.tsx
+++ b/demo/src/components/Footer.tsx
@@ -1,20 +1,20 @@
 
 export function Footer() {
   return (
-    <footer className="bg-gray-900 text-white">
+    <footer className="bg-neutral text-neutral-content">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
           {/* Brand */}
           <div className="md:col-span-2">
             <div className="flex items-center gap-3 mb-4">
-              <div className="w-8 h-8 bg-gradient-to-br from-blue-400 to-blue-600 rounded-lg flex items-center justify-center">
-                <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <div className="w-8 h-8 bg-primary text-primary-content rounded-lg flex items-center justify-center">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>
               </div>
               <span className="text-xl font-bold">React Simile Timeline</span>
             </div>
-            <p className="text-gray-400 max-w-md">
+            <p className="text-neutral-content max-w-md">
               A modern React implementation of the MIT SIMILE Timeline visualization component.
               Open source under the MIT license.
             </p>
@@ -22,20 +22,20 @@ export function Footer() {
 
           {/* Links */}
           <div>
-            <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">Resources</h4>
+            <h4 className="text-sm font-semibold uppercase tracking-wider text-neutral-content mb-4">Resources</h4>
             <ul className="space-y-3">
               <li>
-                <a href="#demos" className="text-gray-300 hover:text-white transition-colors">
+                <a href="#demos" className="text-neutral-content hover:text-neutral-content transition-colors">
                   Demos
                 </a>
               </li>
               <li>
-                <a href="#installation" className="text-gray-300 hover:text-white transition-colors">
+                <a href="#installation" className="text-neutral-content hover:text-neutral-content transition-colors">
                   Installation
                 </a>
               </li>
               <li>
-                <a href="#api" className="text-gray-300 hover:text-white transition-colors">
+                <a href="#api" className="text-neutral-content hover:text-neutral-content transition-colors">
                   API Reference
                 </a>
               </li>
@@ -44,14 +44,14 @@ export function Footer() {
 
           {/* Community */}
           <div>
-            <h4 className="text-sm font-semibold uppercase tracking-wider text-gray-400 mb-4">Community</h4>
+            <h4 className="text-sm font-semibold uppercase tracking-wider text-neutral-content mb-4">Community</h4>
             <ul className="space-y-3">
               <li>
                 <a
                   href="https://github.com/thbst16/react-simile-timeline"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition-colors flex items-center gap-2"
+                  className="text-neutral-content hover:text-neutral-content transition-colors flex items-center gap-2"
                 >
                   <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                     <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
@@ -64,7 +64,7 @@ export function Footer() {
                   href="https://www.npmjs.com/package/react-simile-timeline"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition-colors flex items-center gap-2"
+                  className="text-neutral-content hover:text-neutral-content transition-colors flex items-center gap-2"
                 >
                   <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                     <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331z" />
@@ -77,7 +77,7 @@ export function Footer() {
                   href="https://github.com/thbst16/react-simile-timeline/issues"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition-colors"
+                  className="text-neutral-content hover:text-neutral-content transition-colors"
                 >
                   Report an Issue
                 </a>
@@ -87,7 +87,7 @@ export function Footer() {
                   href="https://github.com/thbst16/react-simile-timeline/blob/main/CONTRIBUTING.md"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-gray-300 hover:text-white transition-colors"
+                  className="text-neutral-content hover:text-neutral-content transition-colors"
                 >
                   Contributing Guide
                 </a>
@@ -97,9 +97,9 @@ export function Footer() {
         </div>
 
         {/* Bottom */}
-        <div className="mt-12 pt-8 border-t border-gray-800 flex flex-col sm:flex-row items-center justify-between gap-4">
-          <p className="text-gray-400 text-sm">
-            Released under the MIT License. Copyright 2024.
+        <div className="mt-12 pt-8 border-t border-neutral-content/20 flex flex-col sm:flex-row items-center justify-between gap-4">
+          <p className="text-neutral-content text-sm">
+            Released under the MIT License. Copyright 2026.
           </p>
           <div className="flex items-center gap-4">
             <a
@@ -107,7 +107,7 @@ export function Footer() {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="View react-simile-timeline on GitHub"
-              className="text-gray-400 hover:text-white transition-colors"
+              className="text-neutral-content hover:text-neutral-content transition-colors"
             >
               <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
                 <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />

--- a/demo/src/components/Header.tsx
+++ b/demo/src/components/Header.tsx
@@ -1,28 +1,28 @@
 
 export function Header() {
   return (
-    <header className="sticky top-0 z-50 bg-white/80 backdrop-blur-md border-b border-gray-200">
+    <header className="sticky top-0 z-50 bg-base-100/80 backdrop-blur-md border-b border-base-300">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-gradient-to-br from-blue-500 to-blue-700 rounded-lg flex items-center justify-center">
-              <svg className="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <div className="w-8 h-8 bg-primary text-primary-content rounded-lg flex items-center justify-center">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
               </svg>
             </div>
-            <span className="text-xl font-bold text-gray-900">React Simile Timeline</span>
+            <span className="text-xl font-bold text-base-content">React Simile Timeline</span>
           </div>
 
           {/* Navigation */}
           <nav className="hidden md:flex items-center gap-8">
-            <a href="#demos" className="text-gray-600 hover:text-gray-900 font-medium transition-colors">
+            <a href="#demos" className="text-base-content/80 hover:text-base-content font-medium transition-colors">
               Demos
             </a>
-            <a href="#installation" className="text-gray-600 hover:text-gray-900 font-medium transition-colors">
+            <a href="#installation" className="text-base-content/80 hover:text-base-content font-medium transition-colors">
               Installation
             </a>
-            <a href="#api" className="text-gray-600 hover:text-gray-900 font-medium transition-colors">
+            <a href="#api" className="text-base-content/80 hover:text-base-content font-medium transition-colors">
               API
             </a>
           </nav>
@@ -33,7 +33,7 @@ export function Header() {
               href="https://www.npmjs.com/package/react-simile-timeline"
               target="_blank"
               rel="noopener noreferrer"
-              className="hidden sm:flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 transition-colors"
+              className="hidden sm:flex items-center gap-2 text-sm text-base-content/80 hover:text-base-content transition-colors"
             >
               <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M0 7.334v8h6.666v1.332H12v-1.332h12v-8H0zm6.666 6.664H5.334v-4H3.999v4H1.335V8.667h5.331v5.331zm4 0v1.336H8.001V8.667h5.334v5.332h-2.669v-.001zm12.001 0h-1.33v-4h-1.336v4h-1.335v-4h-1.33v4h-2.671V8.667h8.002v5.331z" />
@@ -44,7 +44,7 @@ export function Header() {
               href="https://github.com/thbst16/react-simile-timeline"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 px-4 py-2 bg-gray-900 text-white rounded-lg hover:bg-gray-800 transition-colors font-medium text-sm"
+              className="btn btn-neutral btn-sm gap-2"
             >
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />

--- a/demo/src/components/Hero.tsx
+++ b/demo/src/components/Hero.tsx
@@ -11,34 +11,34 @@ export function Hero() {
   };
 
   return (
-    <section className="relative overflow-hidden bg-gradient-to-b from-blue-50 to-white py-20 sm:py-32">
+    <section className="relative overflow-hidden bg-gradient-to-b from-base-200 to-base-100 py-20 sm:py-32">
       {/* Background decoration */}
       <div className="absolute inset-0 overflow-hidden">
-        <div className="absolute -top-40 -right-32 w-80 h-80 bg-blue-100 rounded-full opacity-50 blur-3xl" />
-        <div className="absolute -bottom-40 -left-32 w-80 h-80 bg-indigo-100 rounded-full opacity-50 blur-3xl" />
+        <div className="absolute -top-40 -right-32 w-80 h-80 bg-primary/20 rounded-full opacity-60 blur-3xl" />
+        <div className="absolute -bottom-40 -left-32 w-80 h-80 bg-secondary/20 rounded-full opacity-60 blur-3xl" />
       </div>
 
       <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center">
           {/* Badge */}
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-blue-100 text-blue-700 rounded-full text-sm font-medium mb-8">
+          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary text-primary-content rounded-full text-sm font-medium mb-8">
             <span className="relative flex h-2 w-2">
-              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75"></span>
-              <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-600"></span>
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-primary-content opacity-75"></span>
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-primary-content"></span>
             </span>
             v1.2.0 Released
           </div>
 
           {/* Headline */}
-          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-gray-900 tracking-tight">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-base-content tracking-tight">
             <span className="block">Beautiful Interactive</span>
-            <span className="block bg-gradient-to-r from-blue-600 to-indigo-600 bg-clip-text text-transparent">
+            <span className="block bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent">
               Timeline Visualizations
             </span>
           </h1>
 
           {/* Subheadline */}
-          <p className="mt-6 text-xl text-gray-600 max-w-3xl mx-auto">
+          <p className="mt-6 text-xl text-base-content/80 max-w-3xl mx-auto">
             A modern React implementation of the MIT SIMILE Timeline. Create stunning,
             interactive timelines with multiple bands, event markers, hot zones, and rich customization.
           </p>
@@ -47,7 +47,7 @@ export function Hero() {
           <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-4">
             <a
               href="#demos"
-              className="w-full sm:w-auto px-8 py-4 bg-blue-600 text-white rounded-xl hover:bg-blue-700 transition-colors font-semibold text-lg shadow-lg shadow-blue-600/25"
+              className="btn btn-primary btn-lg w-full sm:w-auto shadow-lg shadow-primary/25"
             >
               View Demos
             </a>
@@ -55,7 +55,7 @@ export function Hero() {
               href="https://github.com/thbst16/react-simile-timeline"
               target="_blank"
               rel="noopener noreferrer"
-              className="w-full sm:w-auto px-8 py-4 bg-white text-gray-900 rounded-xl hover:bg-gray-50 transition-colors font-semibold text-lg border border-gray-200 shadow-sm flex items-center justify-center gap-2"
+              className="btn btn-outline btn-lg w-full sm:w-auto gap-2"
             >
               <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
                 <path fillRule="evenodd" clipRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.831.092-.646.35-1.086.636-1.336-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.578 9.578 0 0112 6.836c.85.004 1.705.114 2.504.336 1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z" />
@@ -66,16 +66,17 @@ export function Hero() {
 
           {/* Install Command */}
           <div className="mt-12 max-w-xl mx-auto">
-            <div className="flex items-center gap-2 bg-gray-900 rounded-xl p-4 shadow-2xl">
-              <span className="text-gray-500 select-none">$</span>
-              <code className="flex-1 text-gray-100 font-mono text-sm sm:text-base">{installCommand}</code>
+            <div className="flex items-center gap-2 bg-neutral text-neutral-content rounded-xl p-4 shadow-2xl">
+              <span className="text-neutral-content select-none">$</span>
+              <code className="flex-1 text-neutral-content font-mono text-sm sm:text-base text-left">{installCommand}</code>
               <button
                 onClick={handleCopy}
-                className="p-2 text-gray-400 hover:text-white transition-colors rounded-lg hover:bg-gray-800"
+                className="p-2 text-neutral-content hover:text-neutral-content transition-colors rounded-lg hover:bg-white/10"
                 title="Copy to clipboard"
+                aria-label="Copy install command"
               >
                 {copied ? (
-                  <svg className="w-5 h-5 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 text-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                   </svg>
                 ) : (
@@ -95,11 +96,11 @@ export function Hero() {
               'Multi-Band',
               'Hot Zones',
               'Themes',
-              'Accessible',
+              'WCAG 2.1 AA',
             ].map((feature) => (
               <span
                 key={feature}
-                className="px-4 py-2 bg-white border border-gray-200 rounded-full text-sm text-gray-600 shadow-sm"
+                className="badge badge-lg badge-outline border-base-300 text-base-content/80 py-3"
               >
                 {feature}
               </span>

--- a/demo/tailwind.config.js
+++ b/demo/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import daisyui from 'daisyui';
+
 export default {
   content: [
     "./index.html",
@@ -7,5 +9,12 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [],
+  plugins: [daisyui],
+  // daisyUI drives the whole site's look. `corporate` is the active theme;
+  // `dark` is kept as the prefers-dark fallback. Swapping the site's style later
+  // is a one-line change here (and the data-theme on the app root).
+  daisyui: {
+    themes: ['corporate', 'dark'],
+    logs: false,
+  },
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.0
         version: 10.5.4(postcss@8.5.26)
+      daisyui:
+        specifier: ^4.12.24
+        version: 4.12.24(postcss@8.5.26)
       postcss:
         specifier: ^8.5.23
         version: 8.5.26
@@ -950,6 +953,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-selector-tokenizer@0.8.0:
+    resolution: {integrity: sha512-Jd6Ig3/pe62/qe5SBPTN8h8LeUg/pT4lLgtavPf7updwwHpvFzxvOQBHYj2LZDMjUnBzgvIUSjRcf6oT5HzHFg==}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -964,6 +970,14 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  culori@3.3.0:
+    resolution: {integrity: sha512-pHJg+jbuFsCjz9iclQBqyL3B2HLCBF71BwVNujUYEvCeQMvV97R59MNK3R2+jgJ3a1fcZgI9B3vYgz8lzr/BFQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  daisyui@4.12.24:
+    resolution: {integrity: sha512-JYg9fhQHOfXyLadrBrEqCDM6D5dWCSSiM6eTNCRrBRzx/VlOCrLS8eDfIw9RVvs64v2mJdLooKXY8EwQzoszAA==}
+    engines: {node: '>=16.9.0'}
 
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
@@ -1158,6 +1172,9 @@ packages:
 
   fast-uri@3.1.5:
     resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fastparse@1.1.2:
+    resolution: {integrity: sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3021,6 +3038,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-selector-tokenizer@0.8.0:
+    dependencies:
+      cssesc: 3.0.0
+      fastparse: 1.1.2
+
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
@@ -3031,6 +3053,17 @@ snapshots:
       rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
+
+  culori@3.3.0: {}
+
+  daisyui@4.12.24(postcss@8.5.26):
+    dependencies:
+      css-selector-tokenizer: 0.8.0
+      culori: 3.3.0
+      picocolors: 1.1.1
+      postcss-js: 4.1.0(postcss@8.5.26)
+    transitivePeerDependencies:
+      - postcss
 
   data-urls@5.0.0:
     dependencies:
@@ -3274,6 +3307,8 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.5: {}
+
+  fastparse@1.1.2: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
Executes **§1** of the [v1.3.0 plan](plans/2026-08-20-demo-rebrand-and-final-hardening-plan.md): rebrand the demo off the default-Tailwind blue/purple onto a deliberate, swappable daisyUI theme.

## What changed
- Adopts **daisyUI** (Tailwind plugin) driven by the **corporate** theme — crisp white base, royal-blue primary. Swapping the whole site's look later is a one-line `data-theme` change in `tailwind.config.js` + `index.html`.
- Migrates all five components + `App.tsx` off hardcoded `blue/indigo/purple/gray` utilities onto daisyUI semantic tokens (`base-*`, `primary`, `neutral`, `btn`, `badge`, `card`).
- Fixes the stale Footer copyright (**2024 → 2026**). (Hero badge `v1.0.2 → v1.2.0` already shipped in #85.)

## Contrast — the guard earned its keep
The axe gate (now run against the production build) flagged real contrast failures from the first theme tried (nord's mid-tone tokens fell just under 4.5:1). The fix is **theme-agnostic**: brand color is used for backgrounds/buttons with `-content` text rather than as body text, and `-content` text on dark surfaces runs at full opacity. Corporate then passes cleanly with margin.

## Verification
- `pnpm lint`, `typecheck` clean.
- **axe WCAG 2 A/AA gate green** across default, dark, and popup states.
- **36 production-preview e2e pass** (`E2E_PREVIEW=1` — the real bundle, per the guard added after the blank-page incident).

Demo-only; no library or published-package change. Merging redeploys the demo on Vercel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)