### PR TITLE
fix(popup): render the event popup in its theme when portaled to body (#74)

### DIFF
--- a/demo/tests/popup-theme.spec.ts
+++ b/demo/tests/popup-theme.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+// #74: the event popup portals to document.body, escaping the themed timeline
+// root. Before the fix its CSS variables fell back to the light defaults even
+// under the dark theme. This drives the real demo: switch the Theming timeline
+// to dark, open a popup, and assert its background actually computes dark.
+
+test.describe('popup theming (#74)', () => {
+  test('the popup renders dark under the dark theme', async ({ page }) => {
+    await page.goto('/');
+    const theming = page.locator('[data-testid="timeline-container"]').nth(1);
+    await theming.locator('.timeline-event[role="button"]').first().waitFor();
+
+    // Switch the Theming demo timeline to the dark theme.
+    await page.getByRole('button', { name: 'Dark', exact: true }).click();
+    await page.waitForTimeout(300);
+
+    // Open a popup from that timeline.
+    await theming.locator('.timeline-event[role="button"]').first().click();
+    const popup = page.locator('.timeline-popup');
+    await expect(popup).toBeVisible();
+
+    const bg = await popup.evaluate((el) => getComputedStyle(el).backgroundColor);
+    const [r, g, b] = bg.match(/\d+/g)!.map(Number);
+    // Dark theme popup background is #2a2a2a; every channel is low. A light
+    // fallback (#ffffff) would put all channels near 255.
+    expect(Math.max(r, g, b)).toBeLessThan(90);
+  });
+});

--- a/packages/react-simile-timeline/src/components/EventPopup.test.tsx
+++ b/packages/react-simile-timeline/src/components/EventPopup.test.tsx
@@ -78,6 +78,37 @@ describe('EventPopup — rendering', () => {
     renderPopup({ start: 'garbage-date', title: 'Odd' });
     expect(screen.getByText('garbage-date')).toBeInTheDocument();
   });
+
+  it('wraps the portal in a themed root so a theme resolves outside .timeline-root (#74)', () => {
+    // The popup portals to document.body, escaping the timeline root. Without a
+    // themed wrapper its CSS variables would fall back to the light defaults
+    // even under the dark theme.
+    function Opener() {
+      const { actions } = useTimelineContext();
+      return (
+        <button onClick={() => actions.setSelectedEvent(event, { x: 50, y: 50 })}>
+          open
+        </button>
+      );
+    }
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TimelineProvider events={[event]}>{children}</TimelineProvider>
+    );
+    render(
+      <>
+        <Opener />
+        <EventPopup themeAttr="dark" themeStyles={{ ['--popup-bg' as string]: '#123456' }} />
+      </>,
+      { wrapper }
+    );
+    fireEvent.click(screen.getByText('open'));
+
+    const themedRoot = screen.getByRole('dialog').closest('.timeline-root');
+    expect(themedRoot).not.toBeNull();
+    expect(themedRoot).toHaveAttribute('data-theme', 'dark');
+    // Custom-theme variables ride along on the same wrapper.
+    expect((themedRoot as HTMLElement).style.getPropertyValue('--popup-bg')).toBe('#123456');
+  });
 });
 
 describe('EventPopup — dismissal', () => {

--- a/packages/react-simile-timeline/src/components/EventPopup.tsx
+++ b/packages/react-simile-timeline/src/components/EventPopup.tsx
@@ -6,6 +6,10 @@ import { formatDate, parseDate } from '../utils/dateUtils';
 export interface EventPopupProps {
   /** Container element for positioning reference */
   containerRef?: React.RefObject<HTMLElement | null>;
+  /** The timeline's resolved `data-theme` value (e.g. 'classic', 'dark', or a custom theme name) */
+  themeAttr?: string;
+  /** Inline CSS-variable overrides for a custom (object) theme */
+  themeStyles?: React.CSSProperties;
 }
 
 /**
@@ -51,7 +55,7 @@ function calculatePopupPosition(
  * Event details popup component
  * Renders as a portal for proper z-index handling
  */
-export function EventPopup(_props: EventPopupProps) {
+export function EventPopup({ themeAttr, themeStyles }: EventPopupProps) {
   const { state, actions } = useTimelineContext();
   const popupRef = useRef<HTMLDivElement>(null);
   const { selectedEvent, clickPosition } = state;
@@ -350,6 +354,21 @@ export function EventPopup(_props: EventPopupProps) {
     </div>
   );
 
-  // Render as portal to body for proper z-index
-  return createPortal(popupContent, document.body);
+  // Render as portal to body for proper z-index. The portal escapes the themed
+  // `.timeline-root`, so the popup's CSS custom properties (--popup-bg, etc.)
+  // would otherwise fall back to their light inline defaults even under the dark
+  // or a custom theme (#74). Wrap the content in a boxless (`display: contents`)
+  // `.timeline-root` carrying the same `data-theme` and custom-theme variables,
+  // so those properties resolve and cascade into the popup without the wrapper
+  // painting a box of its own.
+  return createPortal(
+    <div
+      className="timeline-root"
+      data-theme={themeAttr}
+      style={{ display: 'contents', ...themeStyles }}
+    >
+      {popupContent}
+    </div>,
+    document.body
+  );
 }

--- a/packages/react-simile-timeline/src/components/Timeline.tsx
+++ b/packages/react-simile-timeline/src/components/Timeline.tsx
@@ -311,7 +311,11 @@ export function Timeline({
         onEventHover={onEventHover}
       >
         <TimelineBands />
-        <EventPopup containerRef={containerRef} />
+        <EventPopup
+          containerRef={containerRef}
+          themeAttr={themeAttr}
+          themeStyles={themeStyles as React.CSSProperties}
+        />
       </TimelineProvider>
       {brandingConfig && <TimelineBranding config={brandingConfig} />}
     </div>


### PR DESCRIPTION
Executes the popup-theming fix from the v1.3.0 hardening ([#74](https://github.com/thbst16/react-simile-timeline/issues/74)).

## Problem
`EventPopup` renders through `createPortal(…, document.body)`, escaping the themed `.timeline-root`. Its CSS custom properties (`--popup-bg`, `--popup-title-color`, …) never resolve outside that root, so under the **dark** or a **custom** theme the popup fell back to its light inline defaults — dark title text on a light box, while the surrounding timeline was themed dark.

## Fix
Wrap the portal content in a boxless (`display: contents`) `.timeline-root` element carrying the timeline's resolved `data-theme` and any custom-theme CSS variables. Those properties now resolve and cascade into the popup, while the wrapper paints no box of its own (so the `document.body` portal — needed for z-index/overflow escape — is unchanged). `Timeline` passes the already-computed `themeAttr`/`themeStyles` down.

## Verification
- `pnpm lint`, `typecheck` clean; unit **128 passed** (added a test asserting the wrapper carries `data-theme` + custom vars).
- e2e **37 passed**, including a new `popup-theme.spec.ts` that switches the demo's Theming timeline to dark, opens a popup, and asserts its background computes dark (`#2a2a2a`) rather than the light fallback.
- axe WCAG 2 A/AA gate still green.

Additive prop only (`EventPopup` gains optional `themeAttr`/`themeStyles`); no breaking public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)