### PR TITLE
chore(lint): adopt the actionable @eslint-react rules, decline two with evidence (#72)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,15 +63,30 @@ export default tseslint.config(
       '@typescript-eslint/explicit-module-boundary-types': 'off',
 
       // @eslint-react's recommended-typescript is stricter than the
-      // eslint-plugin-react recommended it replaced. These rules flag existing,
-      // working patterns the previous config never enforced; they are disabled
-      // to keep the ESLint 10 migration behaviour-preserving. Adopting them -
-      // starting with the genuinely real web-api-no-leaked-fetch finding - is a
-      // separate quality pass tracked in #72.
-      '@eslint-react/no-array-index-key': 'off',
-      '@eslint-react/set-state-in-effect': 'off',
-      '@eslint-react/web-api-no-leaked-fetch': 'off',
+      // eslint-plugin-react recommended it replaced. #72 assessed each rule
+      // parked during the ESLint 10 migration.
+      //
+      // Adopted (real findings, now fixed):
+      //   web-api-no-leaked-fetch - the URL fetches use an AbortController.
+      //   no-array-index-key      - list keys derive from the data, not the index.
+      '@eslint-react/web-api-no-leaked-fetch': 'error',
+      '@eslint-react/no-array-index-key': 'error',
+      //
+      // Kept off - the rule fights a legitimate pattern in this codebase:
+      //   use-state: demands the setter be named `set<State>`, but the raw
+      //     useState setters are deliberately `...State`-suffixed
+      //     (setSelectedEventState, setHoveredEventState, setCenterDateState) so
+      //     they don't collide with the public actions setSelectedEvent /
+      //     setHoveredEvent / setCenterDate, which do more than set state.
+      //     Renaming would shadow those actions.
+      //   set-state-in-effect: fires on the async data-loading effects
+      //     (setLoading / setError / setTimelineData) and the centerDate
+      //     prop-sync - an idiomatic pattern whose only clean fix is a data-layer
+      //     refactor, not a bug fix. It is a React-Compiler-style optimisation
+      //     hint and belongs with that rule set's adoption, deferred separately
+      //     (see the react-hooks note above).
       '@eslint-react/use-state': 'off',
+      '@eslint-react/set-state-in-effect': 'off',
 
       // These two suggest React 19-only forms - rendering `<Context>` directly
       // as a provider, and the `use` hook in place of `useContext`. Neither

--- a/packages/react-simile-timeline/src/components/EventTrack.tsx
+++ b/packages/react-simile-timeline/src/components/EventTrack.tsx
@@ -76,13 +76,13 @@ export function EventTrack({
         minHeight: totalHeight,
       }}
     >
-      {layoutEvents.map((layoutEvent, index) => {
+      {layoutEvents.map((layoutEvent) => {
         // Calculate y position based on track
         const y = layoutEvent.track * (trackHeight + trackGap) + trackGap;
 
         return (
           <EventMarker
-            key={`${layoutEvent.event.title}-${layoutEvent.event.start}-${index}`}
+            key={`${layoutEvent.event.title}-${layoutEvent.event.start}-${layoutEvent.event.end ?? ''}`}
             event={layoutEvent.event}
             x={layoutEvent.x}
             y={y}

--- a/packages/react-simile-timeline/src/components/HotZones.tsx
+++ b/packages/react-simile-timeline/src/components/HotZones.tsx
@@ -85,9 +85,9 @@ export function HotZones({
         overflow: 'hidden',
       }}
     >
-      {visibleHotZones.map((hz, index) => (
+      {visibleHotZones.map((hz) => (
         <div
-          key={`hotzone-${index}-${hz.zone.start}`}
+          key={`hotzone-${hz.zone.start}-${hz.zone.end}`}
           className="timeline-hot-zone"
           // An annotated zone conveys information (a named period), so expose it
           // as a note carrying that text. An un-annotated zone is a purely

--- a/packages/react-simile-timeline/src/components/OverviewMarkers.tsx
+++ b/packages/react-simile-timeline/src/components/OverviewMarkers.tsx
@@ -66,9 +66,9 @@ export function OverviewMarkers({
         paddingBottom: 4,
       }}
     >
-      {markers.map((marker, index) => (
+      {markers.map((marker) => (
         <div
-          key={`${marker.event.title}-${marker.event.start}-${index}`}
+          key={`${marker.event.title}-${marker.event.start}-${marker.event.end ?? ''}`}
           className="timeline-overview-marker"
           style={{
             position: 'absolute',

--- a/packages/react-simile-timeline/src/components/TimeScale.tsx
+++ b/packages/react-simile-timeline/src/components/TimeScale.tsx
@@ -70,8 +70,8 @@ export function TimeScale({
         }}
       />
       {/* Tick marks and labels */}
-      {ticks.map((tick, index) => (
-        <TickMark key={`${tick.date.getTime()}-${index}`} tick={tick} />
+      {ticks.map((tick) => (
+        <TickMark key={tick.date.getTime()} tick={tick} />
       ))}
     </div>
   );

--- a/packages/react-simile-timeline/src/components/Timeline.tsx
+++ b/packages/react-simile-timeline/src/components/Timeline.tsx
@@ -23,7 +23,7 @@ function TimelineBands() {
     >
       {bands.map((bandConfig, index) => (
         <Band
-          key={bandConfig.id || `band-${index}`}
+          key={bandConfig.id ?? `band-${bandConfig.timeUnit ?? 'auto'}-${bandConfig.overview ? 'ov' : 'main'}-${bandConfig.height ?? ''}`}
           config={bandConfig}
           isPrimary={index === 0 || !bandConfig.syncWith}
         />
@@ -136,61 +136,71 @@ export function Timeline({
 
   // Fetch data from single URL if provided
   useEffect(() => {
-    if (dataUrl) {
-      setLoading(true);
-      setError(null);
+    if (!dataUrl) return;
 
-      fetch(dataUrl)
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`Failed to fetch timeline data: ${response.statusText}`);
-          }
-          return response.json();
-        })
-        .then((json: TimelineData) => {
-          setTimelineData(json);
-          setLoading(false);
-        })
-        .catch((err) => {
-          setError(err.message);
-          setLoading(false);
-        });
-    }
+    // Abort the request if the URL changes or the component unmounts, so a
+    // late response can't set state on a stale/torn-down component.
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    fetch(dataUrl, { signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to fetch timeline data: ${response.statusText}`);
+        }
+        return response.json();
+      })
+      .then((json: TimelineData) => {
+        setTimelineData(json);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        setError(err.message);
+        setLoading(false);
+      });
+
+    return () => controller.abort();
   }, [dataUrl]);
 
   // Fetch and merge data from multiple URLs if provided
   useEffect(() => {
-    if (dataUrls && dataUrls.length > 0) {
-      setLoading(true);
-      setError(null);
+    if (!dataUrls || dataUrls.length === 0) return;
 
-      Promise.all(
-        dataUrls.map(url =>
-          fetch(url)
-            .then(response => {
-              if (!response.ok) {
-                throw new Error(`Failed to fetch from ${url}: ${response.statusText}`);
-              }
-              return response.json() as Promise<TimelineData>;
-            })
-        )
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    Promise.all(
+      dataUrls.map(url =>
+        fetch(url, { signal: controller.signal })
+          .then(response => {
+            if (!response.ok) {
+              throw new Error(`Failed to fetch from ${url}: ${response.statusText}`);
+            }
+            return response.json() as Promise<TimelineData>;
+          })
       )
-        .then((results) => {
-          // Merge all events from multiple sources
-          const mergedEvents = results.flatMap(result => result.events || []);
-          // Use the first result's metadata as base
-          const mergedData: TimelineData = {
-            ...results[0],
-            events: mergedEvents,
-          };
-          setTimelineData(mergedData);
-          setLoading(false);
-        })
-        .catch((err) => {
-          setError(err.message);
-          setLoading(false);
-        });
-    }
+    )
+      .then((results) => {
+        // Merge all events from multiple sources
+        const mergedEvents = results.flatMap(result => result.events || []);
+        // Use the first result's metadata as base
+        const mergedData: TimelineData = {
+          ...results[0],
+          events: mergedEvents,
+        };
+        setTimelineData(mergedData);
+        setLoading(false);
+      })
+      .catch((err) => {
+        if (err.name === 'AbortError') return;
+        setError(err.message);
+        setLoading(false);
+      });
+
+    return () => controller.abort();
   }, [dataUrls]);
 
   // Update data when prop changes


### PR DESCRIPTION
Assesses the four `@eslint-react` rules parked during the ESLint 10 migration ([#72](https://github.com/thbst16/react-simile-timeline/issues/72)) and acts on each.

## Adopted — real findings, fixed, now enforced
| Rule | Fix |
|---|---|
| `web-api-no-leaked-fetch` | The `dataUrl` / `dataUrls` fetch effects now use an `AbortController` and abort on unmount or dependency change — a late response can no longer set state on a torn-down component. |
| `no-array-index-key` | Marker, hot-zone, tick, and band lists key on their **data** (title+start+end, zone start+end, tick time, band config) instead of the array index. |

## Kept off — the rule fights a legitimate pattern here (rationale recorded in `eslint.config.js`)
- **`use-state`** demands `set<State>` setter names, but the raw `useState` setters are deliberately `…State`-suffixed (`setSelectedEventState`, `setHoveredEventState`, `setCenterDateState`) so they don't collide with the **public** `actions.setSelectedEvent` / `setHoveredEvent` / `setCenterDate` wrappers — which do more than set state. Renaming would shadow those actions.
- **`set-state-in-effect`** fires on the idiomatic async data-loading effects (`setLoading`/`setError`/`setTimelineData`) and the `centerDate` prop-sync. Its only clean fix is a data-layer refactor, not a bug fix; it's a React-Compiler-style optimisation hint and belongs with that rule set's adoption, which is deferred separately.

This is a deliberate 2-of-4 adoption with the two declines evidenced, not a blanket enable or a silent skip.

## Verification
`pnpm lint` / `typecheck` clean · unit **127 pass** · **36 production-preview e2e pass** (URL-data-source loading still works under the AbortController).

🤖 Generated with [Claude Code](https://claude.com/claude-code)