### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zone magnification effect
 - Visual regression testing
 
+## [1.3.0] - 2026-08-20
+
+### Fixed
+
+- **The event popup now renders in the timeline's theme
+  ([#74](https://github.com/thbst16/react-simile-timeline/issues/74)).** The
+  popup portals to `document.body`, escaping the themed `.timeline-root`, so its
+  CSS custom properties never resolved and it fell back to the light inline
+  defaults — dark title text on a light box even when the timeline was themed
+  dark. The portal content is now wrapped in a boxless (`display: contents`)
+  `.timeline-root` carrying the timeline's `data-theme` and any custom-theme
+  variables, so the popup resolves the dark and custom palettes correctly.
+- **URL data sources no longer leak a fetch on unmount.** The `dataUrl` and
+  `dataUrls` effects use an `AbortController` and abort on unmount or when the
+  source changes, so a late response can't set state on a torn-down component
+  (part of [#72](https://github.com/thbst16/react-simile-timeline/issues/72)).
+
+### Changed
+
+- **Event, hot-zone, tick, and band list keys derive from their data** rather
+  than the array index, so rows keep their identity across pans and zooms
+  ([#72](https://github.com/thbst16/react-simile-timeline/issues/72)). Two of the
+  four `@eslint-react` rules parked during the ESLint 10 migration were adopted
+  (`web-api-no-leaked-fetch`, `no-array-index-key`); the other two were declined
+  with the rationale recorded in `eslint.config.js`. Dev-only lint change plus
+  the runtime key/fetch fixes above — no public API change.
+
 ## [1.2.0] - 2026-08-20
 
 ### Added

--- a/demo/src/components/Hero.tsx
+++ b/demo/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export function Hero() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-600"></span>
             </span>
-            v1.2.0 Released
+            v1.3.0 Released
           </div>
 
           {/* Headline */}

--- a/packages/react-simile-timeline/package.json
+++ b/packages/react-simile-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simile-timeline",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "A modern React implementation of the MIT SIMILE Timeline visualization component. Create interactive, multi-band timelines with point and duration events, hot zones, themes, and 100% Simile JSON compatibility.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Version bump for the **1.3.0** release (§5).

- `packages/react-simile-timeline/package.json`: `1.2.0` → `1.3.0`
- CHANGELOG: `[1.3.0]` entry with the popup-theme fix, the fetch-leak fix, and the list-key change
- Demo hero badge: `v1.2.0` → `v1.3.0`

## What 1.3.0 is
A small correctness release — no public API change since 1.2.0:
- **Popup renders in its theme (#74)** — dark/custom themes resolve instead of falling back to light when the popup is portaled.
- **URL fetches abort on unmount** — no state-set on a torn-down component (part of #72).
- **Data-derived list keys** — markers/zones/ticks/bands keep identity across pan/zoom (#72).

## Release sequence (owner-applied)
This PR only bumps the version. When ready:
1. Merge this PR.
2. **Publish path** — your call: the proven `NPM_TOKEN` path (as 1.2.0 shipped), or an OIDC retry after re-checking the npmjs.com trusted-publisher config (#42). The workflow on `main` is currently the token path.
3. `git tag v1.3.0 && git push origin v1.3.0` — **irreversible**; the workflow guards that the tag matches `package.json`. Tag from a `main` that already contains this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)