### PR TITLE
ci(release): swap to OIDC trusted publishing, replacing NPM_TOKEN (#42)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,19 +4,45 @@ on:
   push:
     tags:
       - 'v*'
-  # Manual dry check of the NPM_TOKEN secret. Selects the verify-token job
-  # only - it can never publish. See the job guards below.
+  # Manual OIDC-readiness preflight. Selects the preflight job only; it can
+  # never publish. See the job guards below.
   workflow_dispatch:
 
+# ------------------------------------------------------------------------------
+# Publishing to npm via OIDC trusted publishing.
+#
+# There is no long-lived NPM_TOKEN in this workflow. On a pushed tag, npm mints
+# a short-lived credential by exchanging the job's OIDC token (`id-token: write`)
+# with the registry, provided a trusted publisher for this package is registered
+# on npmjs.com. Provenance is generated automatically as part of that exchange.
+#
+# BEFORE this workflow can publish, the maintainer must register the trusted
+# publisher on npmjs.com (owner-applied, one time):
+#   npmjs.com -> react-simile-timeline -> Settings -> Trusted Publishing
+#   Provider:  GitHub Actions
+#   Owner/repo: thbst16/react-simile-timeline
+#   Workflow:   release.yml
+#   Environment: (leave blank)
+#
+# Two facts this workflow depends on, both verified before it was written:
+#   1. Trusted publishing needs npm >= 11.5.1. The runner's Node 20 ships npm
+#      10.8.2, so npm is upgraded explicitly below.
+#   2. `npm pack` run from the package directory DROPS the root LICENSE, because
+#      the LICENSE lives at the workspace root, not in the package. `pnpm pack`
+#      pulls it in. So the tarball is built with pnpm and published with npm:
+#      pnpm for correct contents, npm for the OIDC exchange. Publishing straight
+#      through `pnpm publish` is avoided — its recursive path rebuilds the npm
+#      invocation and has already been observed to silently drop publish flags
+#      (see the 1.0.3 provenance finding, #17).
+# ------------------------------------------------------------------------------
+
 jobs:
-  # There is no way to confirm the publish credential short of using it, and
-  # using it for real is the irreversible step. This job answers "is the token
-  # still good?" with a whoami and nothing else: no build, no pack, no publish.
-  #
-  # Run it from the Actions tab before pushing a release tag. A dead token
-  # discovered here costs nothing; discovered after tagging it costs a version
-  # number, because the tag is consumed whether or not the publish succeeds.
-  verify-token:
+  # OIDC-readiness preflight. Unlike the old NPM_TOKEN whoami, there is no
+  # credential to test ahead of time — the OIDC exchange only happens during a
+  # real publish. This job confirms the one thing that IS checkable without
+  # burning a version: that the runner's npm is new enough, and prints the
+  # manual checklist the maintainer must confirm on npmjs.com.
+  preflight:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -27,38 +53,42 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
 
-      - name: Check NPM_TOKEN against the registry
+      - name: Confirm npm supports OIDC trusted publishing
         run: |
           set -euo pipefail
-          if ! who=$(npm whoami 2>&1); then
-            echo "::error::NPM_TOKEN is not accepted by the registry. Do not push a release tag until it is replaced."
-            echo "$who"
+          npm install -g npm@^11.5.1
+          ver="$(npm --version)"
+          major="${ver%%.*}"
+          minor="$(echo "$ver" | cut -d. -f2)"
+          echo "npm version after upgrade: ${ver}"
+          if [ "$major" -lt 11 ] || { [ "$major" -eq 11 ] && [ "$minor" -lt 5 ]; }; then
+            echo "::error::npm ${ver} is too old for OIDC trusted publishing (need >= 11.5.1)."
             exit 1
           fi
-          echo "NPM_TOKEN authenticates as: ${who}"
-          echo "Publish rights are a separate question - confirm this account can publish react-simile-timeline."
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          echo "npm is OIDC-capable."
+          echo "::notice::Confirm on npmjs.com that a trusted publisher is registered for react-simile-timeline (GitHub Actions, thbst16/react-simile-timeline, release.yml). OIDC readiness cannot be verified from CI without a real publish."
 
   publish:
-    # Belt and braces: this job runs for a pushed tag and nothing else, so a
-    # manual dispatch cannot reach the publish step however the triggers change.
+    # Runs for a pushed v* tag and nothing else, so a manual dispatch cannot
+    # reach the publish step however the triggers change.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # The OIDC token this mints is the entire credential — there is no
+      # NPM_TOKEN. npm exchanges it with the registry for a short-lived
+      # publish token and attaches provenance.
       id-token: write
 
     steps:
       - uses: actions/checkout@v4
 
-      # The tag is the only trigger for this workflow, and publishing is
-      # irreversible - npm's unpublish window is narrow and using it permanently
-      # burns the version number. That is how 1.0.0 was lost on this package.
-      # A tag that disagrees with package.json is one way to repeat it, so it
-      # fails here, in seconds, before anything is built or pushed anywhere.
+      # The tag is the only trigger, and publishing is irreversible — npm's
+      # unpublish window is narrow and using it permanently burns the version
+      # number. That is how 1.0.0 was lost. A tag that disagrees with
+      # package.json is one way to repeat it, so it fails here, in seconds,
+      # before anything is built or pushed anywhere.
       - name: Verify tag matches package version
         run: |
           set -euo pipefail
@@ -81,26 +111,31 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # The runner's Node 20 ships npm 10.8.2; OIDC trusted publishing needs
+      # >= 11.5.1. Pinned to 11.x for reproducibility rather than @latest.
+      - name: Upgrade npm for OIDC support
+        run: |
+          set -euo pipefail
+          npm install -g npm@^11.5.1
+          echo "npm version: $(npm --version)"
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Build library
         run: pnpm build:lib
 
-      # Provenance is switched on through `publishConfig.provenance` in the
-      # package's package.json, NOT through a `--provenance` flag here.
-      #
-      # `pnpm --filter <pkg> publish` takes pnpm's recursive publish path, and
-      # on the pinned pnpm (9.0.0) that path discards the invoking argv and
-      # rebuilds the npm command from scratch: it forwards only --access,
-      # --dry-run and --otp. A `--provenance` flag on this line would be
-      # accepted by the CLI, silently dropped, and produce an unattested
-      # release that looks like it worked. `publishConfig` travels inside the
-      # packed tarball's manifest instead, so npm reads it whichever path pnpm
-      # takes. Verified: the field is present in the packed package.json.
-      #
-      # `id-token: write` above is what lets npm mint the attestation.
-      - name: Publish to NPM
-        run: pnpm --filter react-simile-timeline publish --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Pack with pnpm (includes the root LICENSE, which npm pack from the
+      # package directory would drop), then publish the tarball with npm so the
+      # OIDC exchange is npm's own, not filtered through pnpm's publish path.
+      - name: Pack tarball
+        run: pnpm --filter react-simile-timeline pack --pack-destination "$RUNNER_TEMP/pack"
+
+      - name: Publish to npm via OIDC
+        run: |
+          set -euo pipefail
+          tgz="$(ls "$RUNNER_TEMP"/pack/react-simile-timeline-*.tgz)"
+          echo "Publishing ${tgz}"
+          # No NODE_AUTH_TOKEN: npm authenticates via the OIDC token minted by
+          # `id-token: write`. Provenance is automatic under trusted publishing.
+          npm publish "$tgz" --access public


### PR DESCRIPTION
> ## ⚠️ DRAFT — owner-applied. Do not merge until the trusted publisher is registered.

Restores the OIDC release workflow (the #63 version, **with `registry-url`**) to finish the token→OIDC cutover ([#42](https://github.com/thbst16/react-simile-timeline/issues/42)). On a pushed tag, npm mints a short-lived credential from the job's OIDC token — no stored `NPM_TOKEN`, provenance automatic.

## The real blocker is on npm, not in this workflow
The 1.2.0 OIDC attempt **signed provenance successfully** and then failed the registry PUT with `404 Not Found`. Under OIDC, that 404 means npm found **no matching trusted publisher** for this package — a registration on npmjs.com, not a workflow bug. (Removing `registry-url` in the follow-up #82 only made npm stop attempting OIDC at all — `ENEEDAUTH` — so `registry-url` is kept here.)

So the retry succeeds only if the npmjs.com registration matches this workflow **exactly**:

| Field | Must be |
|---|---|
| Provider | GitHub Actions |
| Organization / owner | `thbst16` |
| Repository | `react-simile-timeline` |
| Workflow filename | `release.yml` — the filename only, not `.github/workflows/release.yml`, not `Release` |
| Environment | **blank** (the publish job declares no environment) |

Also confirm it's saved on the **package** (Settings → Trusted Publishing) under an account with publish rights to `react-simile-timeline`.

## Activation sequence
1. **Register / fix the trusted publisher** on npmjs.com per the table above.
2. Run the **preflight** (Actions → Release → Run workflow) — confirms the runner's npm is OIDC-capable (it can't verify the registration itself).
3. **Merge this PR.**
4. Bump to the next version, then `git tag vX.Y.Z && git push` — publishes via OIDC with provenance.
5. After a confirmed OIDC release, `gh secret delete NPM_TOKEN`.

## Fallback
If OIDC still 404s, the **token path is currently on `main`** and proven (shipped 1.1.0–1.3.0). Reverting is a one-file change; no release is blocked on OIDC.

## Residual risk
OIDC readiness can't be fully verified from CI without a real publish (the exchange only happens at publish time). The first tag after merge is the test; if the registration doesn't match, it fails **after** build and consumes one version number — recoverable by bumping to the next patch (same irreducible risk the token path always had).

🤖 Generated with [Claude Code](https://claude.com/claude-code)