### PR TITLE
release: 1.3.1 (OIDC cutover validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zone magnification effect
 - Visual regression testing
 
+## [1.3.1] - 2026-08-21
+
+### Changed
+
+- **Releases now publish through npm OIDC trusted publishing instead of a
+  long-lived `NPM_TOKEN`
+  ([#42](https://github.com/thbst16/react-simile-timeline/issues/42)).** On a
+  pushed tag the release workflow mints a short-lived credential from the job's
+  GitHub OIDC token and npm attaches provenance automatically; no publish secret
+  is stored in the repository. The published package is otherwise identical to
+  `1.3.0` — this release carries no code changes, only the supply-chain change in
+  how it is published.
+
 ## [1.3.0] - 2026-08-20
 
 ### Fixed

--- a/demo/src/components/Hero.tsx
+++ b/demo/src/components/Hero.tsx
@@ -26,7 +26,7 @@ export function Hero() {
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-blue-500 opacity-75"></span>
               <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-600"></span>
             </span>
-            v1.3.0 Released
+            v1.3.1 Released
           </div>
 
           {/* Headline */}

--- a/packages/react-simile-timeline/package.json
+++ b/packages/react-simile-timeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simile-timeline",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A modern React implementation of the MIT SIMILE Timeline visualization component. Create interactive, multi-band timelines with point and duration events, hot zones, themes, and 100% Simile JSON compatibility.",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps to **1.3.1** to validate the OIDC trusted-publishing cutover ([#42](https://github.com/thbst16/react-simile-timeline/issues/42)) end-to-end. No code changes since 1.3.0 — only the CHANGELOG entry, version, and demo badge. The published package is identical to 1.3.0; this release exercises the new publish path (short-lived OIDC credential, automatic provenance, no `NPM_TOKEN`).

After a confirmed OIDC publish: `NPM_TOKEN` gets deleted and #42 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)